### PR TITLE
Refactor transform endpoint to Server-Sent Events (SSE) for real-time updates

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -20,6 +20,9 @@ urlencoding = "2.1.3"
 openssl = { version = "0.10.72", features = ["vendored"] }
 pq-sys = { version = "0.6", features = ["bundled"] }
 url = "2.5.4"
+futures = "0.3"
+tokio = { version = "1.38.0", features = ["full"] }
+tokio-stream = "0.1"
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -47,7 +47,8 @@ fn rocket() -> Rocket<Build> {
                 routes::spaces::read,
                 routes::spaces::upload,
                 routes::spaces::import,
-                routes::spaces::transform,
+                routes::spaces::transform_sse,
+                routes::spaces::transform_status,
                 routes::spaces::explore
             ],
         )

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -6,6 +6,12 @@ use std::io::prelude::*;
 use url::Url;
 use uuid::Uuid;
 use rocket::tokio::io::AsyncReadExt;
+use rocket::response::stream::{EventStream, Event};
+use rocket::tokio::time::{sleep, Duration};
+use rocket::tokio::time::interval;
+use tokio_stream::wrappers::IntervalStream;
+use rocket::response::Responder;
+use futures::stream::{Stream, StreamExt};
 
 use rocket::{get, post, Data};
 use rocket::response::status::Custom;
@@ -36,12 +42,13 @@ pub struct ExploreOutput {
     pub token: String
 }
 
-#[post("/spaces/<path..>", data = "<transformation>", rank = 2)]
-pub async fn transform(
+// Server-Sent Events endpoint for real-time transformation updates
+#[post("/spaces/transform-sse/<path..>", data = "<transformation>")]
+pub async fn transform_sse(
     token: Token,
     path: PathBuf,
     transformation: Json<Transformation>,
-) -> Result<Json<bool>, Status> {
+) -> Result<EventStream![Event + 'static], Status> {
     let token_namespace = token.namespace.strip_prefix("/").unwrap();
 
     if !transformation.space.starts_with(token_namespace)
@@ -60,10 +67,86 @@ pub async fn transform(
                 .templates(transformation.templates.clone()),
         );
 
+    // start the transformation
     match mork_api_client.dispatch(request).await {
-        Ok(_) => Ok(Json(true)),
+        Ok(_) => {
+            // create the SSE stream
+            let space_path = transformation.space.clone();
+            let token_clone = token.clone();
+            
+            let stream = EventStream! {
+                yield Event::data("Transform initiated successfully").event("status");
+                
+                // poll for completion
+                let mut interval = interval(Duration::from_secs(3));
+                loop {
+                    interval.tick().await;
+                    
+                    let explore_request = ExploreRequest::new()
+                        .namespace(space_path.clone())
+                        .pattern("$x".to_string())
+                        .token("".to_string());
+                    
+                    match mork_api_client.dispatch(explore_request).await {
+                        Ok(_) => {
+                            yield Event::data("Transform completed successfully").event("complete");
+                            break;
+                        },
+                        Err(err_status) if err_status == Status::ServiceUnavailable => {
+                            yield Event::data("Transform in progress...").event("progress");
+                        },
+                        Err(e) => {
+                            yield Event::data(format!("Transform failed: {:?}", e)).event("error");
+                            break;
+                        }
+                    }
+                }
+            };
+            
+            Ok(stream)
+        },
         Err(e) => Err(e),
     }
+}
+
+// SSE endpoint for monitoring transformation status
+#[get("/spaces/transform-status/<path..>?<token>")]
+pub async fn transform_status(
+    path: PathBuf,
+    token: String,
+) -> Result<EventStream![Event + 'static], Status> {
+
+    let mork_api_client = MorkApiClient::new();
+    
+    let stream = EventStream! {
+        yield Event::data("Monitoring transformation status").event("status");
+        
+        let mut interval = interval(Duration::from_secs(3));
+        loop {
+            interval.tick().await;
+            
+            let explore_request = ExploreRequest::new()
+                .namespace(path.clone())
+                .pattern("$x".to_string())
+                .token("".to_string());
+            
+            match mork_api_client.dispatch(explore_request).await {
+                Ok(_) => {
+                    yield Event::data("Transform completed successfully").event("complete");
+                    break;
+                },
+                Err(err_status) if err_status == Status::ServiceUnavailable => {
+                    yield Event::data("Transform in progress...").event("progress");
+                },
+                Err(e) => {
+                    yield Event::data(format!("Transform failed: {:?}", e)).event("error");
+                    break;
+                }
+            }
+        }
+    };
+    
+    Ok(stream)
 }
 
 #[post("/spaces/upload/<path..>", data = "<data>", rank=1)]


### PR DESCRIPTION
---

## Overview

This PR modernizes the transformation workflow by replacing the old synchronous `transform` endpoint with **non-blocking Server-Sent Events (SSE)**.
The change enables clients to receive **live status updates** during transformation, reducing the need for polling and improving responsiveness.

---

## Changes Made

### Dependencies (`Cargo.toml`)

* Added `futures` for async stream handling
* Added `tokio` (with full features) as the async runtime
* Added `tokio-stream` for interval-based polling within SSE

### Main Application (`src/main.rs`)

* Registered new routes:

  * `transform_sse` → Initiates transformations and streams updates
  * `transform_status` → Monitors transformation state
* Removed references to the deprecated synchronous transform endpoint

### Spaces Routes (`src/routes/spaces.rs`)

* Implemented `transform_sse`:

  * Starts a transformation via `MorkApiClient`
  * Streams progress events (`status`, `progress`, `complete`, `error`) in real-time
* Implemented `transform_status`:

  * Provides SSE updates for monitoring an existing namespace transformation
* Removed the legacy `transform` endpoint (blocking request-response model)

---

## Benefits

* **Real-time feedback:** Clients get instant updates without polling loops
* **Non-blocking:** Uses async streaming for efficiency under load
* **Cleaner API design:** Replaces legacy transform endpoint with a more scalable solution

---

## Testing

* `POST /spaces/transform-sse/<namespace>` successfully initiates a transform and streams updates
* `GET /spaces/transform-status/<namespace>` correctly monitors transformation progress

---