### PR TITLE
Feature/use single binary

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -4,6 +4,8 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+include_dir = "0.7"  
+mime_guess = "2.0"
 serde = { version = "1.0.204", features = ["derive"] }
 rocket = { version = "0.5.1", features = ["json"] }
 diesel = { version = "2.2.2", features = ["postgres", "chrono"] }
@@ -19,8 +21,8 @@ reqwest = { version = "0.12.15", features = ["json"] }
 urlencoding = "2.1.3"
 openssl = { version = "0.10.72", features = ["vendored"] }
 pq-sys = { version = "0.6", features = ["bundled"] }
+tokio = { version = "1.38.0", features = ["full"] }
 url = "2.5.4"
 
 [dev-dependencies]
 httpmock = "0.7.0"
-tokio = { version = "1.38.0", features = ["full"] }

--- a/api/src/main.rs
+++ b/api/src/main.rs
@@ -7,20 +7,39 @@ mod model;
 mod mork_api;
 mod routes;
 mod schema;
+mod static_files;
 
 #[launch]
-fn rocket() -> Rocket<Build> {
+async fn rocket() -> Rocket<Build> {
     // TODO: move hardcoded allowed origins to database,
     // or get backend and frontend hosted under same domain
 
     dotenv::dotenv().ok();
 
+    tokio::spawn(async {
+        let mut cmd = tokio::process::Command::new("./mork_server");
+        cmd.env("MORK_SERVER_PORT", "8001");
+
+        match cmd.spawn() {
+            Ok(mut child) => {
+                if let Err(e) = child.wait().await {
+                    eprintln!("MORK server process failed: {e}");
+                }
+            }
+            Err(e) => eprintln!("Failed to start MORK server: {e}"),
+        }
+    });
+
+    tokio::time::sleep(tokio::time::Duration::from_secs(2)).await;
+
+    std::env::set_var("METTA_KG_MORK_URL", "http://localhost:8001");
+
     let allowed_origins =
-        AllowedOrigins::some_exact(&["http://localhost:3000", "https://metta-kg.vercel.app"]);
+        AllowedOrigins::some_exact(&["http://localhost:8000", "http://127.0.0.1:8000"]);
 
     let cors = rocket_cors::CorsOptions {
         allowed_origins,
-        allowed_methods: vec![Method::Get, Method::Post, Method::Delete]
+        allowed_methods: vec![Method::Get, Method::Post, Method::Delete, Method::Options]
             .into_iter()
             .map(From::from)
             .collect(),
@@ -31,7 +50,7 @@ fn rocket() -> Rocket<Build> {
 
     rocket::build()
         .mount(
-            "/",
+            "/api",
             routes![
                 routes::translations::create_from_csv,
                 routes::translations::create_from_nt,
@@ -53,6 +72,7 @@ fn rocket() -> Rocket<Build> {
             ],
         )
         // .mount("/public", FileServer::from("static"))
+        .mount("/", static_files::routes())
         .attach(cors.clone())
         .manage(cors)
 }

--- a/api/src/static_files.rs
+++ b/api/src/static_files.rs
@@ -1,0 +1,38 @@
+use include_dir::{include_dir, Dir};
+use rocket::http::ContentType;
+use rocket::response::content;
+use rocket::{get, routes, Route};
+use std::path::PathBuf;
+
+static ASSETS: Dir<'_> = include_dir!("../frontend/dist");
+
+#[get("/")]
+pub fn index() -> Option<content::RawHtml<&'static [u8]>> {
+    ASSETS
+        .get_file("index.html")
+        .map(|file| content::RawHtml(file.contents()))
+}
+
+#[get("/<file..>")]
+pub fn files(file: PathBuf) -> Option<(ContentType, &'static [u8])> {
+    let filename = file.to_string_lossy();
+    ASSETS.get_file(&*filename).map(|file| {
+        let content_type = mime_guess::from_path(&*filename).first_or_octet_stream();
+        let media_type = format!("{}/{}", content_type.type_(), content_type.subtype());
+        (
+            ContentType::parse_flexible(&media_type).unwrap_or(ContentType::Binary),
+            file.contents(),
+        )
+    })
+}
+#[get("/<_..>", rank = 10)]
+pub fn spa_fallback() -> Option<content::RawHtml<&'static [u8]>> {
+    // Serve index.html for SPA routing
+    ASSETS
+        .get_file("index.html")
+        .map(|file| content::RawHtml(file.contents()))
+}
+
+pub fn routes() -> Vec<Route> {
+    routes![index, files, spa_fallback]
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,4 +1,4 @@
-export const API_URL = import.meta.env.VITE_BACKEND_URL;
+export const API_URL = import.meta.env.VITE_BACKEND_URL + "api";
 
 export interface Token {
   id: number;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -168,24 +168,17 @@ const App = () => {
       <div class="flex-1 flex flex-col">
         <Router>
           <Route path="*" component={AppLayout}>
-            {sidebarSections.map((section) => {
-              {
-                return section.items.map((item) => {
-                  return (
-                    <Route
-                      path={item.to}
-                      component={
-                        item.component ? (
-                          <item.component />
-                        ) : (
-                          <NotImplemented name={item.label} />
-                        )
-                      }
-                    />
-                  );
-                });
-              }
-            })}
+            {sidebarSections.map((section) =>
+              section.items.map((item) => (
+                <Route
+                  path={item.to}
+                  component={
+                    item.component ||
+                    (() => <NotImplemented name={item.label} />)
+                  }
+                />
+              ))
+            )}
           </Route>
         </Router>
       </div>


### PR DESCRIPTION
***

**Descption**

This pull request refactors the application to embed the entire frontend UI directly into the main backend binary. This simplifies deployment and distribution by creating a single, self-contained executable that serves both the API and the user interface.

**Implementation Details**

-   **`include_dir` Crate**: The dist directory is now embedded into the Rust binary at compile time using the `include_dir` crate.
-   **New static_files.rs Module**: This module defines the Rocket routes (`/`, `/<file..>`, and a fallback) necessary to serve the embedded `index.html`, JavaScript, CSS, and other assets.
-   **main.rs Update**: The main application now mounts the routes from `static_files::routes()` at the root (`/`), enabling it to serve the frontend.



