### PR TITLE
Refactor/unindetend tree

### DIFF
--- a/frontend/src/pages/load/components/D3SpaceGraph.tsx
+++ b/frontend/src/pages/load/components/D3SpaceGraph.tsx
@@ -258,7 +258,7 @@ export default function D3TreeGraph(props: D3TreeGraphProps) {
     nodeEnter
       .append("circle")
       .attr("class", "node-icon")
-      .attr("cx", 14)
+      .attr("cx", 11)
       .attr("cy", 0)
       .attr("r", 3)
       .style("fill", "hsl(var(--muted-foreground))")

--- a/frontend/src/pages/load/components/D3SpaceGraph.tsx
+++ b/frontend/src/pages/load/components/D3SpaceGraph.tsx
@@ -89,20 +89,10 @@ export default function D3TreeGraph(props: D3TreeGraphProps) {
   }
 
   const margin = { top: 20, right: 40, bottom: 20, left: 40 };
-  const nodeHeight = 36;
+  const nodeHeight = 24;
   const nodeWidth = 280;
   const duration = 350;
-  const indentSize = 28;
-
-  const connector = (link: d3.HierarchyPointLink<D3Node>) => {
-    const source = link.source;
-    const target = link.target;
-    const midY = source.y + indentSize / 2;
-    return `M${source.y + 20},${source.x}
-            L${midY},${source.x}
-            L${midY},${target.x}
-            L${target.y},${target.x}`;
-  };
+  const indentSize = 0;
 
   const isExpandable = (d: D3Node) => {
     if (d._isLeaf) return false;
@@ -162,8 +152,6 @@ export default function D3TreeGraph(props: D3TreeGraphProps) {
       n.x = idx * nodeHeight;
       n.y = n.depth * indentSize;
     });
-
-    const links = root.links();
 
     const node = g
       .selectAll<SVGGElement, D3Node>("g.node")
@@ -230,18 +218,6 @@ export default function D3TreeGraph(props: D3TreeGraphProps) {
       .style("stroke", "transparent")
       .style("stroke-width", "2px");
 
-    // Connection line to parent
-    nodeEnter
-      .append("line")
-      .attr("class", "parent-line")
-      .attr("x1", 0)
-      .attr("y1", 0)
-      .attr("x2", -indentSize / 2)
-      .attr("y2", 0)
-      .style("stroke", "hsl(var(--muted-foreground))")
-      .style("stroke-width", "1.5px")
-      .style("opacity", (d: D3Node) => (d.depth === 0 ? 0 : 0.5));
-
     const toggleGroup = nodeEnter
       .append("g")
       .attr("class", "toggle-group")
@@ -253,10 +229,10 @@ export default function D3TreeGraph(props: D3TreeGraphProps) {
       .append("rect")
       .attr("class", "toggle-bg")
       .attr("x", 4)
-      .attr("y", -10)
-      .attr("width", 20)
-      .attr("height", 20)
-      .attr("rx", 4)
+      .attr("y", -6)
+      .attr("width", 14)
+      .attr("height", 14)
+      .attr("rx", 2)
       .style("fill", "hsl(var(--muted))")
       .style("stroke", "hsl(var(--border))")
       .style("stroke-width", "1px");
@@ -264,11 +240,11 @@ export default function D3TreeGraph(props: D3TreeGraphProps) {
     toggleGroup
       .append("text")
       .attr("class", "toggle-icon")
-      .attr("x", 14)
-      .attr("y", 0)
+      .attr("x", 11)
+      .attr("y", 1)
       .attr("text-anchor", "middle")
       .attr("dominant-baseline", "middle")
-      .style("font-size", "14px")
+      .style("font-size", "12px")
       .style("font-weight", "700")
       .style("fill", "hsl(var(--foreground))")
       .style("pointer-events", "none")
@@ -340,42 +316,7 @@ export default function D3TreeGraph(props: D3TreeGraphProps) {
       .attr("transform", `translate(${source.y},${source.x})`)
       .remove();
 
-    const link = g
-      .selectAll<SVGPathElement, d3.HierarchyLink<D3Node>>("path.link")
-      .data(links, (d: d3.HierarchyLink<D3Node>) => d.target.id);
-
-    link
-      .enter()
-      .insert("path", "g")
-      .attr("class", "link")
-      .style("fill", "none")
-      .style("stroke", "hsl(var(--muted-foreground))")
-      .style("stroke-width", "2px")
-      .style("opacity", 0)
-      .attr("d", () =>
-        connector({
-          source: { x: source.x0, y: source.y0 },
-          target: { x: source.x0, y: source.y0 },
-        } as d3.HierarchyPointLink<D3Node>)
-      )
-      .merge(link)
-      .transition()
-      .duration(duration)
-      .style("opacity", 0.5)
-      .attr("d", connector);
-
-    link
-      .exit()
-      .transition()
-      .duration(duration)
-      .style("opacity", 0)
-      .attr("d", () =>
-        connector({
-          source: { x: source.x, y: source.y },
-          target: { x: source.x, y: source.y },
-        } as d3.HierarchyPointLink<D3Node>)
-      )
-      .remove();
+    g.selectAll("path.link").remove();
 
     allNodes.forEach((d: D3Node) => {
       d.x0 = d.x;


### PR DESCRIPTION
## Description

This pull request simplifies and streamlines the rendering of the D3 tree graph in `D3SpaceGraph.tsx`. The main focus is on removing custom connector lines between nodes, reducing visual clutter, and making the node and toggle UI elements more compact and visually consistent.

**Removal of connector lines and related logic:**

* Removed the custom `connector` function and all code responsible for drawing and animating connector lines between nodes, including the parent-line and path-based links. This results in a cleaner, less cluttered tree visualization. [[1]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L92-R95) [[2]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L233-L244) [[3]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L343-R319)
* The `indentSize` is now set to `0`, eliminating indentation between tree levels and further simplifying the layout. [[1]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L92-R95) [[2]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L166-L167)

**UI/UX improvements to node and toggle controls:**

* Reduced the size of node elements and toggle controls (e.g., node height from 36 to 24, toggle background from 20x20 to 14x14, font and icon sizes adjusted), making the UI more compact and visually consistent. [[1]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L92-R95) [[2]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L256-R247) [[3]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L285-R261)
* Adjusted the positions of toggle icons and node icons to match the new, smaller control sizes. [[1]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L256-R247) [[2]](diffhunk://#diff-e1a335ee1524aaa6d90e7c1576bbfbebec295bc3f4a7f6889c8686c28be70f02L285-R261)

These changes together make the tree graph more minimal and visually focused on the nodes themselves.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.