### PR TITLE
feat: open external links in a new tab safely

### DIFF
--- a/frontend/src/pages/index/components/Header.tsx
+++ b/frontend/src/pages/index/components/Header.tsx
@@ -9,6 +9,8 @@ export default function Header() {
         <div class="flex items-center gap-4">
           <a
             href="https://github.com/trueagi-io/MORK"
+            target="_blank"
+            rel="noopener noreferrer"
             class="uppercase text-neutral-400 hover:text-primary hover:underline"
           >
             MORK
@@ -16,6 +18,8 @@ export default function Header() {
           <span class="text-primary">·</span>
           <a
             href="https://github.com/trueagi-io/MORK/wiki"
+            target="_blank"
+            rel="noopener noreferrer"
             class="uppercase text-neutral-400 hover:text-primary hover:underline"
           >
             DOCS
@@ -23,6 +27,8 @@ export default function Header() {
           <span class="text-primary">·</span>
           <a
             href="https://chat.singularitynet.io/chat/channels/mork"
+            target="_blank"
+            rel="noopener noreferrer"
             class="uppercase text-neutral-400 hover:text-primary hover:underline"
           >
             COMMUNITY


### PR DESCRIPTION
### Summery

- This change updates all external links to open in a new browser tab using `target="_blank"`, and adds `rel="noopener noreferrer"` for security best practices.  
- This is a small UX and security improvement with no functional impact.