### PR TITLE
feat: add SSE implementation for MeTTa-KG commands

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,7 +21,7 @@ urlencoding = "2.1.3"
 openssl = { version = "0.10.72", features = ["vendored"] }
 pq-sys = { version = "0.6", features = ["bundled"] }
 url = "2.5.4"
-tokio = "1.38.0"
+tokio = { version = "1.38.0", features = ["process", "rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -21,7 +21,7 @@ urlencoding = "2.1.3"
 openssl = { version = "0.10.72", features = ["vendored"] }
 pq-sys = { version = "0.6", features = ["bundled"] }
 url = "2.5.4"
-tokio = { version = "1.38.0", features = ["process", "rt-multi-thread", "macros"] }
+tokio = { version = "1.38.0", features = ["rt-multi-thread", "macros"] }
 
 [dev-dependencies]
 httpmock = "0.7.0"

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -63,6 +63,7 @@ pub fn rocket() -> Rocket<Build> {
                 routes::spaces::union,
             ],
         )
+        .attach(routes::command::stage())
         .attach(cors.clone())
         .manage(cors)
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -63,7 +63,7 @@ pub fn rocket() -> Rocket<Build> {
                 routes::spaces::union,
             ],
         )
-        .attach(routes::command::stage())
+        .attach(routes::sse::stage())
         .attach(cors.clone())
         .manage(cors)
 }

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -9,6 +9,7 @@ pub mod model;
 pub mod mork_api;
 pub mod routes;
 pub mod schema;
+pub mod sse_utils;
 
 pub const MIGRATIONS: EmbeddedMigrations = embed_migrations!("migrations");
 

--- a/api/src/routes/command.rs
+++ b/api/src/routes/command.rs
@@ -3,11 +3,11 @@ use rocket::futures::stream::{self as futures_stream};
 use rocket::response::stream::{Event, EventStream};
 use rocket::serde::{json::Json, Deserialize};
 use rocket::State;
+use rocket::{get, post, routes};
+use std::process::Stdio;
 use tokio::io::{AsyncBufReadExt, BufReader};
 use tokio::process::Command;
 use tokio::sync::{broadcast, mpsc};
-use rocket::{get, post, routes};
-use std::process::Stdio;
 
 #[derive(Clone)]
 pub struct CommandState {

--- a/api/src/routes/command.rs
+++ b/api/src/routes/command.rs
@@ -1,82 +1,13 @@
 use rocket::fairing::AdHoc;
 use rocket::futures::stream::{self as futures_stream};
 use rocket::response::stream::{Event, EventStream};
-use rocket::serde::{json::Json, Deserialize};
 use rocket::State;
-use rocket::{get, post, routes};
-use std::process::Stdio;
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Command;
-use tokio::sync::{broadcast, mpsc};
+use rocket::{get, routes};
+use tokio::sync::broadcast;
 
 #[derive(Clone)]
 pub struct CommandState {
-    pub sender: mpsc::Sender<String>,
     pub broadcaster: broadcast::Sender<String>,
-}
-
-#[derive(Deserialize)]
-pub struct CommandRequest {
-    pub command: String,
-}
-
-pub async fn run_command_processor(
-    mut receiver: mpsc::Receiver<String>,
-    broadcaster: broadcast::Sender<String>,
-) {
-    while let Some(cmd_str) = receiver.recv().await {
-        let _ = broadcaster.send(format!("$ {}\n", cmd_str));
-
-        let mut child = match Command::new("sh")
-            .arg("-c")
-            .arg(&cmd_str)
-            .stdout(Stdio::piped())
-            .stderr(Stdio::piped())
-            .spawn()
-        {
-            Ok(c) => c,
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error spawning command: {}\n", e));
-                continue;
-            }
-        };
-
-        let stdout = child.stdout.take().expect("stdout captured");
-        let stderr = child.stderr.take().expect("stderr captured");
-
-        let tx_out = broadcaster.clone();
-        let tx_err = broadcaster.clone();
-
-        let stdout_task = tokio::spawn(async move {
-            let mut reader = BufReader::new(stdout).lines();
-            while let Ok(Some(line)) = reader.next_line().await {
-                let _ = tx_out.send(format!("{}\n", line));
-            }
-        });
-
-        let stderr_task = tokio::spawn(async move {
-            let mut reader = BufReader::new(stderr).lines();
-            while let Ok(Some(line)) = reader.next_line().await {
-                let _ = tx_err.send(format!("{}\n", line));
-            }
-        });
-
-        let _ = tokio::join!(stdout_task, stderr_task);
-        let _ = child.wait().await;
-    }
-}
-
-#[post("/command", data = "<payload>")]
-pub async fn trigger(
-    state: &State<CommandState>,
-    payload: Json<CommandRequest>,
-) -> Result<(), String> {
-    state
-        .sender
-        .send(payload.command.clone())
-        .await
-        .map_err(|e| e.to_string())?;
-    Ok(())
 }
 
 #[get("/events")]
@@ -97,19 +28,13 @@ pub fn stream(
 
 pub fn stage() -> AdHoc {
     AdHoc::on_ignite("Command Processor", |rocket| async {
-        let (tx_cmd, rx_cmd) = mpsc::channel::<String>(100);
         let (tx_bc, _) = broadcast::channel::<String>(100);
-
-        let tx_bc_clone = tx_bc.clone();
-        tokio::spawn(async move {
-            run_command_processor(rx_cmd, tx_bc_clone).await;
-        });
 
         rocket
             .manage(CommandState {
-                sender: tx_cmd,
+                // sender: tx_cmd,
                 broadcaster: tx_bc,
             })
-            .mount("/", routes![trigger, stream])
+            .mount("/", routes![stream])
     })
 }

--- a/api/src/routes/command.rs
+++ b/api/src/routes/command.rs
@@ -1,0 +1,115 @@
+use rocket::fairing::AdHoc;
+use rocket::futures::stream::{self as futures_stream};
+use rocket::response::stream::{Event, EventStream};
+use rocket::serde::{json::Json, Deserialize};
+use rocket::State;
+use tokio::io::{AsyncBufReadExt, BufReader};
+use tokio::process::Command;
+use tokio::sync::{broadcast, mpsc};
+use rocket::{get, post, routes};
+use std::process::Stdio;
+
+#[derive(Clone)]
+pub struct CommandState {
+    pub sender: mpsc::Sender<String>,
+    pub broadcaster: broadcast::Sender<String>,
+}
+
+#[derive(Deserialize)]
+pub struct CommandRequest {
+    pub command: String,
+}
+
+pub async fn run_command_processor(
+    mut receiver: mpsc::Receiver<String>,
+    broadcaster: broadcast::Sender<String>,
+) {
+    while let Some(cmd_str) = receiver.recv().await {
+        let _ = broadcaster.send(format!("$ {}\n", cmd_str));
+
+        let mut child = match Command::new("sh")
+            .arg("-c")
+            .arg(&cmd_str)
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+        {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error spawning command: {}\n", e));
+                continue;
+            }
+        };
+
+        let stdout = child.stdout.take().expect("stdout captured");
+        let stderr = child.stderr.take().expect("stderr captured");
+
+        let tx_out = broadcaster.clone();
+        let tx_err = broadcaster.clone();
+
+        let stdout_task = tokio::spawn(async move {
+            let mut reader = BufReader::new(stdout).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                let _ = tx_out.send(format!("{}\n", line));
+            }
+        });
+
+        let stderr_task = tokio::spawn(async move {
+            let mut reader = BufReader::new(stderr).lines();
+            while let Ok(Some(line)) = reader.next_line().await {
+                let _ = tx_err.send(format!("{}\n", line));
+            }
+        });
+
+        let _ = tokio::join!(stdout_task, stderr_task);
+        let _ = child.wait().await;
+    }
+}
+
+#[post("/command", data = "<payload>")]
+pub async fn trigger(
+    state: &State<CommandState>,
+    payload: Json<CommandRequest>,
+) -> Result<(), String> {
+    state
+        .sender
+        .send(payload.command.clone())
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[get("/events")]
+pub fn stream(
+    state: &State<CommandState>,
+) -> EventStream<impl rocket::futures::Stream<Item = Event>> {
+    let rx = state.broadcaster.subscribe();
+
+    let stream = futures_stream::unfold(rx, |mut rx| async move {
+        match rx.recv().await {
+            Ok(msg) => Some((Event::data(msg), rx)),
+            Err(_) => None,
+        }
+    });
+
+    EventStream::from(stream)
+}
+
+pub fn stage() -> AdHoc {
+    AdHoc::on_ignite("Command Processor", |rocket| async {
+        let (tx_cmd, rx_cmd) = mpsc::channel::<String>(100);
+        let (tx_bc, _) = broadcast::channel::<String>(100);
+
+        let tx_bc_clone = tx_bc.clone();
+        tokio::spawn(async move {
+            run_command_processor(rx_cmd, tx_bc_clone).await;
+        });
+
+        rocket
+            .manage(CommandState {
+                sender: tx_cmd,
+                broadcaster: tx_bc,
+            })
+            .mount("/", routes![trigger, stream])
+    })
+}

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -12,6 +12,7 @@ use serde::{Deserialize, Serialize};
 pub mod spaces;
 pub mod tokens;
 pub mod translations;
+pub mod command;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum AuthError {

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -9,8 +9,8 @@ use rocket::{
 };
 use serde::{Deserialize, Serialize};
 
-pub mod command;
 pub mod spaces;
+pub mod sse;
 pub mod tokens;
 pub mod translations;
 

--- a/api/src/routes/mod.rs
+++ b/api/src/routes/mod.rs
@@ -9,10 +9,10 @@ use rocket::{
 };
 use serde::{Deserialize, Serialize};
 
+pub mod command;
 pub mod spaces;
 pub mod tokens;
 pub mod translations;
-pub mod command;
 
 #[derive(Serialize, Deserialize, Debug)]
 pub enum AuthError {

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -14,8 +14,8 @@ use tokio::time::{sleep, Duration, Instant};
 use crate::model::Token;
 use crate::mork_api::{
     ClearRequest, ExploreRequest, ExportFormat, ExportRequest, ImportRequest, Mm2Cell,
-    MorkApiClient, Namespace, ReadRequest, StatusRequest, StatusResponse, TransformDetails,
-    TransformRequest, UploadRequest,
+    MorkApiClient, Namespace, ReadRequest, Request, StatusRequest, StatusResponse,
+    TransformDetails, TransformRequest, UploadRequest,
 };
 use crate::routes::sse::SseState;
 use crate::sse_utils::{JobRunner, ServerEvent};
@@ -176,32 +176,7 @@ pub async fn upload(
         .data(body);
 
     let broadcaster = state.broadcaster.clone();
-    let request_path = path;
-
-    JobRunner::spawn(
-        "UPLOAD",
-        broadcaster.clone(),
-        move |tx: broadcast::Sender<ServerEvent>| {
-            let client = mork_api_client;
-            let req = request;
-            async move {
-                client
-                    .dispatch(req)
-                    .await
-                    .map_err(|e| format!("Upload dispatch failed: {:?}", e))?;
-
-                let _ = tx.send(ServerEvent::Log {
-                    message: "Data received, waiting for processing...".to_string(),
-                });
-
-                poll_and_broadcast(request_path, &client, &tx)
-                    .await
-                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
-
-                Ok("File uploaded and processed successfully".to_string())
-            }
-        },
-    );
+    spawn_job("UPLOAD", broadcaster, mork_api_client, request, path);
 
     Ok(Json(true))
 }
@@ -228,31 +203,12 @@ pub async fn import(
     let request = ImportRequest::new().to(template).uri(uri);
 
     let broadcaster = state.broadcaster.clone();
-    let request_path = path.clone();
-
-    JobRunner::spawn(
+    spawn_job(
         "IMPORT",
-        broadcaster.clone(),
-        move |tx: broadcast::Sender<ServerEvent>| {
-            let client = mork_api_client;
-            let req = request;
-            async move {
-                client
-                    .dispatch(req)
-                    .await
-                    .map_err(|e| format!("Import dispatch failed: {:?}", e))?;
-
-                let _ = tx.send(ServerEvent::Log {
-                    message: "Data received, waiting for processing...".to_string(),
-                });
-
-                poll_and_broadcast(request_path, &client, &tx)
-                    .await
-                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
-
-                Ok("Import completed successfully.".to_string())
-            }
-        },
+        broadcaster,
+        mork_api_client,
+        request,
+        path.clone(),
     );
 
     Ok(Json(true))
@@ -360,32 +316,7 @@ pub async fn clear(
     let request = ClearRequest::new().namespace(path.clone()).expr(expr);
 
     let broadcaster = state.broadcaster.clone();
-    let request_path = path.clone();
-
-    JobRunner::spawn(
-        "CLEAR",
-        broadcaster.clone(),
-        move |tx: broadcast::Sender<ServerEvent>| {
-            let client = mork_api_client;
-            let req = request;
-            async move {
-                client
-                    .dispatch(req)
-                    .await
-                    .map_err(|e| format!("Clear dispatch failed: {:?}", e))?;
-
-                let _ = tx.send(ServerEvent::Log {
-                    message: "Data received, waiting for processing...".to_string(),
-                });
-
-                poll_and_broadcast(request_path, &client, &tx)
-                    .await
-                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
-
-                Ok("Clear completed successfully.".to_string())
-            }
-        },
-    );
+    spawn_job("CLEAR", broadcaster, mork_api_client, request, path.clone());
 
     Ok(Json(true))
 }
@@ -421,30 +352,7 @@ pub async fn transform(
     // Convert Namespace to PathBuf for polling
     let path_buf = PathBuf::from(request_path.to_string());
 
-    JobRunner::spawn(
-        "TRANSFORM",
-        broadcaster.clone(),
-        move |tx: broadcast::Sender<ServerEvent>| {
-            let client = mork_api_client;
-            let req = request;
-            async move {
-                client
-                    .dispatch(req)
-                    .await
-                    .map_err(|e| format!("Transform dispatch failed: {:?}", e))?;
-
-                let _ = tx.send(ServerEvent::Log {
-                    message: "Data received, waiting for processing...".to_string(),
-                });
-
-                poll_and_broadcast(path_buf, &client, &tx)
-                    .await
-                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
-
-                Ok("Transform completed successfully.".to_string())
-            }
-        },
-    );
+    spawn_job("TRANSFORM", broadcaster, mork_api_client, request, path_buf);
 
     Ok(Json(true))
 }
@@ -487,29 +395,12 @@ pub async fn composition(
         None => return Err(Status::BadRequest),
     };
 
-    JobRunner::spawn(
+    spawn_job(
         "COMPOSITION",
-        broadcaster.clone(),
-        move |tx: broadcast::Sender<ServerEvent>| {
-            let client = mork_api_client;
-            let req = request;
-            async move {
-                client
-                    .dispatch(req)
-                    .await
-                    .map_err(|e| format!("Composition dispatch failed: {:?}", e))?;
-
-                let _ = tx.send(ServerEvent::Log {
-                    message: "Data received, waiting for processing...".to_string(),
-                });
-
-                poll_and_broadcast(request_path, &client, &tx)
-                    .await
-                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
-
-                Ok("Composition completed successfully.".to_string())
-            }
-        },
+        broadcaster,
+        mork_api_client,
+        request,
+        request_path,
     );
 
     Ok(Json(true))
@@ -651,6 +542,49 @@ async fn poll_and_broadcast(
         }
     }
     Ok(true)
+}
+
+fn spawn_job<R>(
+    command: &str,
+    broadcaster: broadcast::Sender<ServerEvent>,
+    mork_api_client: MorkApiClient,
+    request: R,
+    request_path: PathBuf,
+) where
+    R: Request + Send + Sync + 'static,
+{
+    let command_label = command.to_string();
+    // Capitalize first letter for success message
+    let success_msg = if let Some(first_char) = command.chars().next() {
+        format!(
+            "{}{}",
+            first_char.to_uppercase(),
+            &command.to_lowercase()[1..]
+        )
+    } else {
+        command.to_string()
+    } + " completed successfully.";
+
+    JobRunner::spawn(
+        command,
+        broadcaster,
+        move |tx: broadcast::Sender<ServerEvent>| async move {
+            mork_api_client
+                .dispatch(request)
+                .await
+                .map_err(|e| format!("{} dispatch failed: {:?}", command_label, e))?;
+
+            let _ = tx.send(ServerEvent::Log {
+                message: "Data received, waiting for processing...".to_string(),
+            });
+
+            poll_and_broadcast(request_path, &mork_api_client, &tx)
+                .await
+                .map_err(|e| format!("Processing timeout: {:?}", e))?;
+
+            Ok(success_msg)
+        },
+    );
 }
 
 fn composition_transform(input: SetOperationInput) -> Result<TransformDetails, Status> {

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -17,7 +17,7 @@ use crate::mork_api::{
     MorkApiClient, Namespace, ReadRequest, Request, StatusRequest, StatusResponse,
     TransformDetails, TransformRequest, UploadRequest,
 };
-use crate::routes::command::CommandState;
+use crate::routes::sse::SseState;
 
 trait SourceTargetPermissions {
     type Ns: ToString + Clone;
@@ -145,7 +145,7 @@ pub async fn upload(
     token: Token,
     path: PathBuf,
     data: Data<'_>,
-    state: &State<CommandState>,
+    state: &State<SseState>,
 ) -> Result<Json<bool>, Custom<String>> {
     let token_namespace = token.namespace.strip_prefix("/").unwrap();
     if !path.starts_with(token_namespace) || !token.permission_write {
@@ -196,7 +196,7 @@ pub async fn import(
     token: Token,
     path: PathBuf,
     uri: String,
-    state: &State<CommandState>,
+    state: &State<SseState>,
 ) -> Result<Json<bool>, Status> {
     if !path.starts_with(token.namespace.strip_prefix("/").unwrap()) || !token.permission_write {
         return Err(Status::Unauthorized);
@@ -256,7 +256,7 @@ pub async fn export(
     token: Token,
     path: PathBuf,
     export_input: Json<Mm2Input>,
-    state: &State<CommandState>,
+    state: &State<SseState>,
 ) -> Result<Json<String>, Status> {
     if !path.starts_with(token.namespace.strip_prefix("/").unwrap()) || !token.permission_read {
         return Err(Status::Unauthorized);
@@ -306,7 +306,7 @@ pub async fn clear(
     token: Token,
     path: PathBuf,
     expr: String,
-    state: &State<CommandState>,
+    state: &State<SseState>,
 ) -> Result<Json<bool>, Status> {
     let token_namespace = token.namespace.strip_prefix("/").unwrap();
     if !path.starts_with(token_namespace) || !token.permission_write {
@@ -337,7 +337,7 @@ pub async fn clear(
 pub async fn transform(
     token: Token,
     mm2: Json<Mm2InputMultiWithNamespace>,
-    state: &State<CommandState>,
+    state: &State<SseState>,
 ) -> Result<Json<bool>, Status> {
     let mm2 = mm2.into_inner();
     if !mm2.clone().source_target_permissions(token) {
@@ -395,7 +395,7 @@ pub async fn transform(
 pub async fn composition(
     token: Token,
     operation_input: Json<SetOperationInput>,
-    state: &State<CommandState>,
+    state: &State<SseState>,
 ) -> Result<Json<bool>, Status> {
     if !operation_input.source_target_permissions(token) {
         return Err(Status::Unauthorized);
@@ -462,7 +462,7 @@ pub async fn intersection(
 pub async fn union(
     token: Token,
     operation_input: Json<SetOperationInput>,
-    state: &State<CommandState>,
+    state: &State<SseState>,
 ) -> Result<Json<bool>, Status> {
     if !operation_input.source_target_permissions(token) {
         return Err(Status::Unauthorized);

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -8,16 +8,16 @@ use rocket::response::status::Custom;
 use rocket::serde::json;
 use rocket::{get, post, Data, State};
 use std::path::PathBuf;
-use tokio::time::{sleep, Duration, Instant};
 use tokio::sync::broadcast;
+use tokio::time::{sleep, Duration, Instant};
 
 use crate::model::Token;
-use crate::routes::command::CommandState;
 use crate::mork_api::{
     ClearRequest, ExploreRequest, ExportFormat, ExportRequest, ImportRequest, Mm2Cell,
     MorkApiClient, Namespace, ReadRequest, StatusRequest, StatusResponse, TransformDetails,
     TransformRequest, UploadRequest,
 };
+use crate::routes::command::CommandState;
 
 trait SourceTargetPermissions {
     type Ns: ToString + Clone;
@@ -272,6 +272,7 @@ pub async fn clear(token: Token, path: PathBuf, expr: String) -> Result<Json<boo
 pub async fn transform(
     token: Token,
     mm2: Json<Mm2InputMultiWithNamespace>,
+    state: &State<CommandState>,
 ) -> Result<Json<bool>, Status> {
     let mm2 = mm2.into_inner();
     if !mm2.clone().source_target_permissions(token) {
@@ -282,14 +283,48 @@ pub async fn transform(
     let request = TransformRequest::new().transform_input(
         TransformDetails::new()
             .patterns(mm2.clone().patterns)
-            .templates(mm2.templates),
+            .templates(mm2.templates.clone()),
     );
 
-    // TODO: use server sent events instead
-    match mork_api_client.dispatch(request).await {
-        Ok(_) => Ok(Json(true)),
-        Err(e) => Err(e),
-    }
+    let broadcaster = state.broadcaster.clone();
+    // We need a target path to poll. In transform, templates define the target.
+    // Assuming the first template's namespace is the target for polling.
+    let request_path = match mm2.templates.first() {
+        Some(t) => t.namespace().clone(),
+        None => return Err(Status::BadRequest),
+    };
+
+    tokio::spawn(async move {
+        let _ = broadcaster.send("PROCESS_STARTED".to_string());
+        let _ = broadcaster.send("Starting transform operation...".to_string());
+
+        match mork_api_client.dispatch(request).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Transform dispatched successfully.".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error dispatching transform: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+                return;
+            }
+        };
+
+        // poll status endpoint
+        // Convert Namespace to PathBuf for polling
+        let path_buf = PathBuf::from(request_path.to_string());
+        match poll_and_broadcast(path_buf, &mork_api_client, &broadcaster).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Poll successful.".to_string());
+                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+            }
+        }
+    });
+
+    Ok(Json(true))
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -311,20 +346,54 @@ pub async fn transform(
 pub async fn composition(
     token: Token,
     operation_input: Json<SetOperationInput>,
+    state: &State<CommandState>,
 ) -> Result<Json<bool>, Status> {
     if !operation_input.source_target_permissions(token) {
         return Err(Status::Unauthorized);
     }
 
-    let transform_input = composition_transform(operation_input.into_inner())?;
+    let input = operation_input.into_inner();
+    let transform_input = composition_transform(input.clone())?;
 
     let request = TransformRequest::new().transform_input(transform_input.clone());
     let mork_api_client = MorkApiClient::new();
+    let broadcaster = state.broadcaster.clone();
 
-    match mork_api_client.dispatch(request).await {
-        Ok(_) => Ok(Json(true)),
-        Err(e) => Err(e),
-    }
+    // Target path for polling is the first target in the input
+    let request_path = match input.target.first() {
+        Some(t) => PathBuf::from(t),
+        None => return Err(Status::BadRequest),
+    };
+
+    tokio::spawn(async move {
+        let _ = broadcaster.send("PROCESS_STARTED".to_string());
+        let _ = broadcaster.send("Starting composition operation...".to_string());
+
+        match mork_api_client.dispatch(request).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Composition dispatched successfully.".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error dispatching composition: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+                return;
+            }
+        };
+
+        // poll status endpoint
+        match poll_and_broadcast(request_path, &mork_api_client, &broadcaster).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Poll successful.".to_string());
+                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+            }
+        }
+    });
+
+    Ok(Json(true))
 }
 
 /// Performs an intersection operation on provided namespaces. `token` must have `permission_write`
@@ -398,7 +467,9 @@ pub async fn union(
             };
 
             // poll status endpoint
-            match poll_and_broadcast(PathBuf::from(&request_path), &mork_api_client, &broadcaster).await {
+            match poll_and_broadcast(PathBuf::from(&request_path), &mork_api_client, &broadcaster)
+                .await
+            {
                 Ok(_) => {
                     let _ = broadcaster.send("Poll successful.".to_string());
                 }
@@ -459,6 +530,7 @@ async fn poll_and_broadcast(
     Ok(true)
 }
 
+#[allow(dead_code)]
 async fn poll(path: PathBuf, mork_api_client: &MorkApiClient) -> Result<bool, Status> {
     let start_time = Instant::now();
     let timeout_duration = Duration::from_secs(40);

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -6,11 +6,13 @@ use url::Url;
 
 use rocket::response::status::Custom;
 use rocket::serde::json;
-use rocket::{get, post, Data};
+use rocket::{get, post, Data, State};
 use std::path::PathBuf;
 use tokio::time::{sleep, Duration, Instant};
+use tokio::sync::broadcast;
 
 use crate::model::Token;
+use crate::routes::command::CommandState;
 use crate::mork_api::{
     ClearRequest, ExploreRequest, ExportFormat, ExportRequest, ImportRequest, Mm2Cell,
     MorkApiClient, Namespace, ReadRequest, StatusRequest, StatusResponse, TransformDetails,
@@ -360,6 +362,7 @@ pub async fn intersection(
 pub async fn union(
     token: Token,
     operation_input: Json<SetOperationInput>,
+    state: &State<CommandState>,
 ) -> Result<Json<bool>, Status> {
     if !operation_input.source_target_permissions(token) {
         return Err(Status::Unauthorized);
@@ -374,18 +377,40 @@ pub async fn union(
     // create a vector of queries
     let transform_inputs = union_transform(operation_input.into_inner())?;
     let mork_api_client = MorkApiClient::new();
+    let broadcaster = state.broadcaster.clone();
 
-    for transform_input in transform_inputs {
-        let request = TransformRequest::new().transform_input(transform_input);
+    tokio::spawn(async move {
+        let _ = broadcaster.send("PROCESS_STARTED".to_string());
+        let _ = broadcaster.send("Starting union operation...".to_string());
 
-        match mork_api_client.dispatch(request).await {
-            Ok(_) => {}
-            Err(e) => return Err(e),
-        };
+        for transform_input in transform_inputs {
+            let request = TransformRequest::new().transform_input(transform_input);
 
-        // poll status endpoint
-        poll(PathBuf::from(&request_path), &mork_api_client).await?;
-    }
+            match mork_api_client.dispatch(request).await {
+                Ok(_) => {
+                    let _ = broadcaster.send("Transform dispatched successfully.".to_string());
+                }
+                Err(e) => {
+                    let _ = broadcaster.send(format!("Error dispatching transform: {:?}", e));
+                    let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+                    return;
+                }
+            };
+
+            // poll status endpoint
+            match poll_and_broadcast(PathBuf::from(&request_path), &mork_api_client, &broadcaster).await {
+                Ok(_) => {
+                    let _ = broadcaster.send("Poll successful.".to_string());
+                }
+                Err(e) => {
+                    let _ = broadcaster.send(format!("Error polling status: {:?}", e));
+                    let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+                    return;
+                }
+            }
+        }
+        let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
+    });
 
     Ok(Json(true))
 }
@@ -393,6 +418,46 @@ pub async fn union(
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////// HELPER FUNCTIONS ////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+async fn poll_and_broadcast(
+    path: PathBuf,
+    mork_api_client: &MorkApiClient,
+    broadcaster: &broadcast::Sender<String>,
+) -> Result<bool, Status> {
+    let start_time = Instant::now();
+    let timeout_duration = Duration::from_secs(40);
+
+    // Check if space is clear by using status endpoint
+    let check_request = StatusRequest::new()
+        .namespace(path.clone())
+        .pattern("$x".to_string());
+
+    loop {
+        // exit condition stop polling after some second
+        if start_time.elapsed() > timeout_duration {
+            return Err(Status::RequestTimeout);
+        }
+
+        // wait 1 second between each status request
+        sleep(Duration::from_millis(1000)).await;
+        let _ = broadcaster.send("Checking status...".to_string());
+
+        // destructure status endpoint json response
+        let status_response: StatusResponse =
+            match mork_api_client.dispatch(check_request.clone()).await {
+                Ok(result) => match json::from_str::<StatusResponse>(&result) {
+                    Ok(c) => c,
+                    Err(_) => return Err(Status::RequestTimeout),
+                },
+                Err(_) => return Err(Status::RequestTimeout),
+            };
+
+        if status_response.status == "pathClear" {
+            break;
+        }
+    }
+    Ok(true)
+}
 
 async fn poll(path: PathBuf, mork_api_client: &MorkApiClient) -> Result<bool, Status> {
     let start_time = Instant::now();

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -254,6 +254,7 @@ pub async fn export(
     token: Token,
     path: PathBuf,
     export_input: Json<Mm2Input>,
+    state: &State<CommandState>,
 ) -> Result<Json<String>, Status> {
     if !path.starts_with(token.namespace.strip_prefix("/").unwrap()) || !token.permission_read {
         return Err(Status::Unauthorized);
@@ -266,9 +267,35 @@ pub async fn export(
         .template(export_input.template.clone())
         .format(ExportFormat::Metta);
 
-    match mork_api_client.dispatch(request).await {
-        Ok(data) => Ok(Json(data)),
-        Err(e) => Err(e),
+    let broadcaster = state.broadcaster.clone();
+    let _ = broadcaster.send("PROCESS_STARTED".to_string());
+    let _ = broadcaster.send("Starting export operation...".to_string());
+
+    let dispatch_future = mork_api_client.dispatch(request);
+    tokio::pin!(dispatch_future);
+
+    let mut interval = tokio::time::interval(Duration::from_secs(1));
+
+    let result = loop {
+        tokio::select! {
+            res = &mut dispatch_future => break res,
+            _ = interval.tick() => {
+                let _ = broadcaster.send("Exporting...".to_string());
+            }
+        }
+    };
+
+    match result {
+        Ok(data) => {
+            let _ = broadcaster.send("Export completed successfully.".to_string());
+            let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
+            Ok(Json(data))
+        }
+        Err(e) => {
+            let _ = broadcaster.send(format!("Error during export: {:?}", e));
+            let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+            Err(e)
+        }
     }
 }
 

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -619,42 +619,6 @@ async fn poll_and_broadcast(
     Ok(true)
 }
 
-#[allow(dead_code)] // incase this is necessary in the future
-async fn poll(path: PathBuf, mork_api_client: &MorkApiClient) -> Result<bool, Status> {
-    let start_time = Instant::now();
-    let timeout_duration = Duration::from_secs(40);
-
-    // Check if space is clear by using status endpoint
-    let check_request = StatusRequest::new()
-        .namespace(path.clone())
-        .pattern("$x".to_string());
-
-    loop {
-        // exit condition stop polling after some second
-        if start_time.elapsed() > timeout_duration {
-            return Err(Status::RequestTimeout);
-        }
-
-        // wait 1 second between each status request
-        sleep(Duration::from_millis(1000)).await;
-
-        // destructure status endpoint json response
-        let status_response: StatusResponse =
-            match mork_api_client.dispatch(check_request.clone()).await {
-                Ok(result) => match json::from_str::<StatusResponse>(&result) {
-                    Ok(c) => c,
-                    Err(_) => return Err(Status::RequestTimeout),
-                },
-                Err(_) => return Err(Status::RequestTimeout),
-            };
-
-        if status_response.status == "pathClear" {
-            break;
-        }
-    }
-    Ok(true)
-}
-
 fn composition_transform(input: SetOperationInput) -> Result<TransformDetails, Status> {
     let mut template = String::new();
 

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -182,6 +182,7 @@ pub async fn upload(
         mork_api_client,
         request,
         request_path,
+        "UPLOAD".to_string(),
         "Starting upload operation...".to_string(),
         "Upload dispatched successfully.".to_string(),
     );
@@ -218,6 +219,7 @@ pub async fn import(
         mork_api_client,
         request,
         request_path,
+        "IMPORT".to_string(),
         "Starting import operation...".to_string(),
         "Import dispatched successfully.".to_string(),
     );
@@ -268,7 +270,7 @@ pub async fn export(
         .format(ExportFormat::Metta);
 
     let broadcaster = state.broadcaster.clone();
-    let _ = broadcaster.send("PROCESS_STARTED".to_string());
+    let _ = broadcaster.send("PROCESS_STARTED:EXPORT".to_string());
     let _ = broadcaster.send("Starting export operation...".to_string());
 
     let dispatch_future = mork_api_client.dispatch(request);
@@ -322,6 +324,7 @@ pub async fn clear(
         mork_api_client,
         request,
         request_path,
+        "CLEAR".to_string(),
         "Starting clear operation...".to_string(),
         "Clear dispatched successfully.".to_string(),
     );
@@ -365,6 +368,7 @@ pub async fn transform(
         mork_api_client,
         request,
         path_buf,
+        "TRANSFORM".to_string(),
         "Starting transform operation...".to_string(),
         "Transform dispatched successfully.".to_string(),
     );
@@ -415,6 +419,7 @@ pub async fn composition(
         mork_api_client,
         request,
         request_path,
+        "COMPOSITION".to_string(),
         "Starting composition operation...".to_string(),
         "Composition dispatched successfully.".to_string(),
     );
@@ -475,7 +480,7 @@ pub async fn union(
     let broadcaster = state.broadcaster.clone();
 
     tokio::spawn(async move {
-        let _ = broadcaster.send("PROCESS_STARTED".to_string());
+        let _ = broadcaster.send("PROCESS_STARTED:UNION".to_string());
         let _ = broadcaster.send("Starting union operation...".to_string());
 
         for transform_input in transform_inputs {
@@ -544,13 +549,14 @@ fn spawn_polling_job<R>(
     mork_api_client: MorkApiClient,
     request: R,
     request_path: PathBuf,
+    command_type: String,
     start_msg: String,
     dispatch_msg: String,
 ) where
     R: Request + Send + Sync + 'static,
 {
     tokio::spawn(async move {
-        let _ = broadcaster.send("PROCESS_STARTED".to_string());
+        let _ = broadcaster.send(format!("PROCESS_STARTED:{}", command_type));
         let _ = broadcaster.send(start_msg);
 
         if execute_polling_job(

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -14,8 +14,8 @@ use tokio::time::{sleep, Duration, Instant};
 use crate::model::Token;
 use crate::mork_api::{
     ClearRequest, ExploreRequest, ExportFormat, ExportRequest, ImportRequest, Mm2Cell,
-    MorkApiClient, Namespace, ReadRequest, StatusRequest, StatusResponse, TransformDetails,
-    TransformRequest, UploadRequest,
+    MorkApiClient, Namespace, ReadRequest, Request, StatusRequest, StatusResponse,
+    TransformDetails, TransformRequest, UploadRequest,
 };
 use crate::routes::command::CommandState;
 
@@ -177,33 +177,14 @@ pub async fn upload(
     let broadcaster = state.broadcaster.clone();
     let request_path = path;
 
-    tokio::spawn(async move {
-        let _ = broadcaster.send("PROCESS_STARTED".to_string());
-        let _ = broadcaster.send("Starting upload operation...".to_string());
-
-        match mork_api_client.dispatch(request).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Upload dispatched successfully.".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error dispatching upload: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-                return;
-            }
-        };
-
-        // poll status endpoint
-        match poll_and_broadcast(request_path, &mork_api_client, &broadcaster).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Poll successful.".to_string());
-                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-            }
-        }
-    });
+    spawn_polling_job(
+        broadcaster,
+        mork_api_client,
+        request,
+        request_path,
+        "Starting upload operation...".to_string(),
+        "Upload dispatched successfully.".to_string(),
+    );
 
     Ok(Json(true))
 }
@@ -232,33 +213,14 @@ pub async fn import(
     let broadcaster = state.broadcaster.clone();
     let request_path = path.clone();
 
-    tokio::spawn(async move {
-        let _ = broadcaster.send("PROCESS_STARTED".to_string());
-        let _ = broadcaster.send("Starting import operation...".to_string());
-
-        match mork_api_client.dispatch(request).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Import dispatched successfully.".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error dispatching import: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-                return;
-            }
-        };
-
-        // poll status endpoint
-        match poll_and_broadcast(request_path, &mork_api_client, &broadcaster).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Poll successful.".to_string());
-                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-            }
-        }
-    });
+    spawn_polling_job(
+        broadcaster,
+        mork_api_client,
+        request,
+        request_path,
+        "Starting import operation...".to_string(),
+        "Import dispatched successfully.".to_string(),
+    );
 
     Ok(Json(true))
 }
@@ -328,33 +290,14 @@ pub async fn clear(
     let broadcaster = state.broadcaster.clone();
     let request_path = path.clone();
 
-    tokio::spawn(async move {
-        let _ = broadcaster.send("PROCESS_STARTED".to_string());
-        let _ = broadcaster.send("Starting clear operation...".to_string());
-
-        match mork_api_client.dispatch(request).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Clear dispatched successfully.".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error dispatching clear: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-                return;
-            }
-        };
-
-        // poll status endpoint
-        match poll_and_broadcast(request_path, &mork_api_client, &broadcaster).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Poll successful.".to_string());
-                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-            }
-        }
-    });
+    spawn_polling_job(
+        broadcaster,
+        mork_api_client,
+        request,
+        request_path,
+        "Starting clear operation...".to_string(),
+        "Clear dispatched successfully.".to_string(),
+    );
 
     Ok(Json(true))
 }
@@ -386,35 +329,18 @@ pub async fn transform(
         None => return Err(Status::BadRequest),
     };
 
-    tokio::spawn(async move {
-        let _ = broadcaster.send("PROCESS_STARTED".to_string());
-        let _ = broadcaster.send("Starting transform operation...".to_string());
+    // poll status endpoint
+    // Convert Namespace to PathBuf for polling
+    let path_buf = PathBuf::from(request_path.to_string());
 
-        match mork_api_client.dispatch(request).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Transform dispatched successfully.".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error dispatching transform: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-                return;
-            }
-        };
-
-        // poll status endpoint
-        // Convert Namespace to PathBuf for polling
-        let path_buf = PathBuf::from(request_path.to_string());
-        match poll_and_broadcast(path_buf, &mork_api_client, &broadcaster).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Poll successful.".to_string());
-                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-            }
-        }
-    });
+    spawn_polling_job(
+        broadcaster,
+        mork_api_client,
+        request,
+        path_buf,
+        "Starting transform operation...".to_string(),
+        "Transform dispatched successfully.".to_string(),
+    );
 
     Ok(Json(true))
 }
@@ -457,33 +383,14 @@ pub async fn composition(
         None => return Err(Status::BadRequest),
     };
 
-    tokio::spawn(async move {
-        let _ = broadcaster.send("PROCESS_STARTED".to_string());
-        let _ = broadcaster.send("Starting composition operation...".to_string());
-
-        match mork_api_client.dispatch(request).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Composition dispatched successfully.".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error dispatching composition: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-                return;
-            }
-        };
-
-        // poll status endpoint
-        match poll_and_broadcast(request_path, &mork_api_client, &broadcaster).await {
-            Ok(_) => {
-                let _ = broadcaster.send("Poll successful.".to_string());
-                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
-            }
-            Err(e) => {
-                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
-                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-            }
-        }
-    });
+    spawn_polling_job(
+        broadcaster,
+        mork_api_client,
+        request,
+        request_path,
+        "Starting composition operation...".to_string(),
+        "Composition dispatched successfully.".to_string(),
+    );
 
     Ok(Json(true))
 }
@@ -531,7 +438,7 @@ pub async fn union(
 
     // path to be used for polling
     let request_path = match operation_input.clone().into_inner().target.first() {
-        Some(value) => value.clone(),
+        Some(value) => PathBuf::from(value),
         None => return Err(Status::BadRequest),
     };
 
@@ -547,29 +454,17 @@ pub async fn union(
         for transform_input in transform_inputs {
             let request = TransformRequest::new().transform_input(transform_input);
 
-            match mork_api_client.dispatch(request).await {
-                Ok(_) => {
-                    let _ = broadcaster.send("Transform dispatched successfully.".to_string());
-                }
-                Err(e) => {
-                    let _ = broadcaster.send(format!("Error dispatching transform: {:?}", e));
-                    let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-                    return;
-                }
-            };
-
-            // poll status endpoint
-            match poll_and_broadcast(PathBuf::from(&request_path), &mork_api_client, &broadcaster)
-                .await
+            if execute_polling_job(
+                &mork_api_client,
+                &broadcaster,
+                request,
+                request_path.clone(),
+                "Transform dispatched successfully.".to_string(),
+            )
+            .await
+            .is_err()
             {
-                Ok(_) => {
-                    let _ = broadcaster.send("Poll successful.".to_string());
-                }
-                Err(e) => {
-                    let _ = broadcaster.send(format!("Error polling status: {:?}", e));
-                    let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-                    return;
-                }
+                return;
             }
         }
         let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
@@ -581,6 +476,70 @@ pub async fn union(
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////// HELPER FUNCTIONS ////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+async fn execute_polling_job<R>(
+    mork_api_client: &MorkApiClient,
+    broadcaster: &broadcast::Sender<String>,
+    request: R,
+    request_path: PathBuf,
+    dispatch_msg: String,
+) -> Result<(), ()>
+where
+    R: Request + Send + Sync,
+{
+    match mork_api_client.dispatch(request).await {
+        Ok(_) => {
+            let _ = broadcaster.send(dispatch_msg);
+        }
+        Err(e) => {
+            let _ = broadcaster.send(format!("Error dispatching request: {:?}", e));
+            let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+            return Err(());
+        }
+    };
+
+    // poll status endpoint
+    match poll_and_broadcast(request_path, mork_api_client, broadcaster).await {
+        Ok(_) => {
+            let _ = broadcaster.send("Poll successful.".to_string());
+            Ok(())
+        }
+        Err(e) => {
+            let _ = broadcaster.send(format!("Error polling status: {:?}", e));
+            let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+            Err(())
+        }
+    }
+}
+
+fn spawn_polling_job<R>(
+    broadcaster: broadcast::Sender<String>,
+    mork_api_client: MorkApiClient,
+    request: R,
+    request_path: PathBuf,
+    start_msg: String,
+    dispatch_msg: String,
+) where
+    R: Request + Send + Sync + 'static,
+{
+    tokio::spawn(async move {
+        let _ = broadcaster.send("PROCESS_STARTED".to_string());
+        let _ = broadcaster.send(start_msg);
+
+        if execute_polling_job(
+            &mork_api_client,
+            &broadcaster,
+            request,
+            request_path,
+            dispatch_msg,
+        )
+        .await
+        .is_ok()
+        {
+            let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
+        }
+    });
+}
 
 async fn poll_and_broadcast(
     path: PathBuf,
@@ -627,7 +586,7 @@ async fn poll_and_broadcast(
     Ok(true)
 }
 
-#[allow(dead_code)]
+#[allow(dead_code)] // incase this is necessary in the future
 async fn poll(path: PathBuf, mork_api_client: &MorkApiClient) -> Result<bool, Status> {
     let start_time = Instant::now();
     let timeout_duration = Duration::from_secs(40);

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -14,10 +14,11 @@ use tokio::time::{sleep, Duration, Instant};
 use crate::model::Token;
 use crate::mork_api::{
     ClearRequest, ExploreRequest, ExportFormat, ExportRequest, ImportRequest, Mm2Cell,
-    MorkApiClient, Namespace, ReadRequest, Request, StatusRequest, StatusResponse,
-    TransformDetails, TransformRequest, UploadRequest,
+    MorkApiClient, Namespace, ReadRequest, StatusRequest, StatusResponse, TransformDetails,
+    TransformRequest, UploadRequest,
 };
 use crate::routes::sse::SseState;
+use crate::sse_utils::{JobRunner, ServerEvent};
 
 trait SourceTargetPermissions {
     type Ns: ToString + Clone;
@@ -177,14 +178,32 @@ pub async fn upload(
     let broadcaster = state.broadcaster.clone();
     let request_path = path;
 
-    spawn_polling_job(
-        broadcaster,
-        mork_api_client,
-        request,
-        request_path,
-        "UPLOAD".to_string(),
-        "Starting upload operation...".to_string(),
-        "Upload dispatched successfully.".to_string(),
+    JobRunner::spawn(
+        "UPLOAD",
+        broadcaster.clone(),
+        move |tx: broadcast::Sender<ServerEvent>| {
+            let client = mork_api_client;
+            let req = request;
+            async move {
+                let _ = tx.send(ServerEvent::Log {
+                    message: "Starting upload operation...".to_string(),
+                });
+                match client.dispatch(req).await {
+                    Ok(_) => {
+                        let _ = tx.send(ServerEvent::Log {
+                            message: "Upload dispatched successfully.".to_string(),
+                        });
+                    }
+                    Err(e) => {
+                        return Err(format!("Error dispatching request: {:?}", e));
+                    }
+                }
+                match poll_and_broadcast(request_path, &client, &tx).await {
+                    Ok(_) => Ok("Poll successful.".to_string()),
+                    Err(e) => Err(format!("Error polling status: {:?}", e)),
+                }
+            }
+        },
     );
 
     Ok(Json(true))
@@ -214,14 +233,32 @@ pub async fn import(
     let broadcaster = state.broadcaster.clone();
     let request_path = path.clone();
 
-    spawn_polling_job(
-        broadcaster,
-        mork_api_client,
-        request,
-        request_path,
-        "IMPORT".to_string(),
-        "Starting import operation...".to_string(),
-        "Import dispatched successfully.".to_string(),
+    JobRunner::spawn(
+        "IMPORT",
+        broadcaster.clone(),
+        move |tx: broadcast::Sender<ServerEvent>| {
+            let client = mork_api_client;
+            let req = request;
+            async move {
+                let _ = tx.send(ServerEvent::Log {
+                    message: "Starting import operation...".to_string(),
+                });
+                match client.dispatch(req).await {
+                    Ok(_) => {
+                        let _ = tx.send(ServerEvent::Log {
+                            message: "Import dispatched successfully.".to_string(),
+                        });
+                    }
+                    Err(e) => {
+                        return Err(format!("Error dispatching request: {:?}", e));
+                    }
+                }
+                match poll_and_broadcast(request_path, &client, &tx).await {
+                    Ok(_) => Ok("Poll successful.".to_string()),
+                    Err(e) => Err(format!("Error polling status: {:?}", e)),
+                }
+            }
+        },
     );
 
     Ok(Json(true))
@@ -270,8 +307,12 @@ pub async fn export(
         .format(ExportFormat::Metta);
 
     let broadcaster = state.broadcaster.clone();
-    let _ = broadcaster.send("PROCESS_STARTED:EXPORT".to_string());
-    let _ = broadcaster.send("Starting export operation...".to_string());
+    let _ = broadcaster.send(ServerEvent::Started {
+        command: "EXPORT".to_string(),
+    });
+    let _ = broadcaster.send(ServerEvent::Log {
+        message: "Starting export operation...".to_string(),
+    });
 
     let dispatch_future = mork_api_client.dispatch(request);
     tokio::pin!(dispatch_future);
@@ -282,20 +323,28 @@ pub async fn export(
         tokio::select! {
             res = &mut dispatch_future => break res,
             _ = interval.tick() => {
-                let _ = broadcaster.send("Exporting...".to_string());
+                let _ = broadcaster.send(ServerEvent::Log { message: "Exporting...".to_string() });
             }
         }
     };
 
     match result {
         Ok(data) => {
-            let _ = broadcaster.send("Export completed successfully.".to_string());
-            let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
+            let _ = broadcaster.send(ServerEvent::Log {
+                message: "Export completed successfully.".to_string(),
+            });
+            let _ = broadcaster.send(ServerEvent::Success {
+                message: "Export done".to_string(),
+            });
             Ok(Json(data))
         }
         Err(e) => {
-            let _ = broadcaster.send(format!("Error during export: {:?}", e));
-            let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+            let _ = broadcaster.send(ServerEvent::Log {
+                message: format!("Error during export: {:?}", e),
+            });
+            let _ = broadcaster.send(ServerEvent::Error {
+                message: format!("{:?}", e),
+            });
             Err(e)
         }
     }
@@ -319,14 +368,32 @@ pub async fn clear(
     let broadcaster = state.broadcaster.clone();
     let request_path = path.clone();
 
-    spawn_polling_job(
-        broadcaster,
-        mork_api_client,
-        request,
-        request_path,
-        "CLEAR".to_string(),
-        "Starting clear operation...".to_string(),
-        "Clear dispatched successfully.".to_string(),
+    JobRunner::spawn(
+        "CLEAR",
+        broadcaster.clone(),
+        move |tx: broadcast::Sender<ServerEvent>| {
+            let client = mork_api_client;
+            let req = request;
+            async move {
+                let _ = tx.send(ServerEvent::Log {
+                    message: "Starting clear operation...".to_string(),
+                });
+                match client.dispatch(req).await {
+                    Ok(_) => {
+                        let _ = tx.send(ServerEvent::Log {
+                            message: "Clear dispatched successfully.".to_string(),
+                        });
+                    }
+                    Err(e) => {
+                        return Err(format!("Error dispatching request: {:?}", e));
+                    }
+                }
+                match poll_and_broadcast(request_path, &client, &tx).await {
+                    Ok(_) => Ok("Poll successful.".to_string()),
+                    Err(e) => Err(format!("Error polling status: {:?}", e)),
+                }
+            }
+        },
     );
 
     Ok(Json(true))
@@ -363,14 +430,32 @@ pub async fn transform(
     // Convert Namespace to PathBuf for polling
     let path_buf = PathBuf::from(request_path.to_string());
 
-    spawn_polling_job(
-        broadcaster,
-        mork_api_client,
-        request,
-        path_buf,
-        "TRANSFORM".to_string(),
-        "Starting transform operation...".to_string(),
-        "Transform dispatched successfully.".to_string(),
+    JobRunner::spawn(
+        "TRANSFORM",
+        broadcaster.clone(),
+        move |tx: broadcast::Sender<ServerEvent>| {
+            let client = mork_api_client;
+            let req = request;
+            async move {
+                let _ = tx.send(ServerEvent::Log {
+                    message: "Starting transform operation...".to_string(),
+                });
+                match client.dispatch(req).await {
+                    Ok(_) => {
+                        let _ = tx.send(ServerEvent::Log {
+                            message: "Transform dispatched successfully.".to_string(),
+                        });
+                    }
+                    Err(e) => {
+                        return Err(format!("Error dispatching request: {:?}", e));
+                    }
+                }
+                match poll_and_broadcast(path_buf, &client, &tx).await {
+                    Ok(_) => Ok("Poll successful.".to_string()),
+                    Err(e) => Err(format!("Error polling status: {:?}", e)),
+                }
+            }
+        },
     );
 
     Ok(Json(true))
@@ -414,14 +499,32 @@ pub async fn composition(
         None => return Err(Status::BadRequest),
     };
 
-    spawn_polling_job(
-        broadcaster,
-        mork_api_client,
-        request,
-        request_path,
-        "COMPOSITION".to_string(),
-        "Starting composition operation...".to_string(),
-        "Composition dispatched successfully.".to_string(),
+    JobRunner::spawn(
+        "COMPOSITION",
+        broadcaster.clone(),
+        move |tx: broadcast::Sender<ServerEvent>| {
+            let client = mork_api_client;
+            let req = request;
+            async move {
+                let _ = tx.send(ServerEvent::Log {
+                    message: "Starting composition operation...".to_string(),
+                });
+                match client.dispatch(req).await {
+                    Ok(_) => {
+                        let _ = tx.send(ServerEvent::Log {
+                            message: "Composition dispatched successfully.".to_string(),
+                        });
+                    }
+                    Err(e) => {
+                        return Err(format!("Error dispatching request: {:?}", e));
+                    }
+                }
+                match poll_and_broadcast(request_path, &client, &tx).await {
+                    Ok(_) => Ok("Poll successful.".to_string()),
+                    Err(e) => Err(format!("Error polling status: {:?}", e)),
+                }
+            }
+        },
     );
 
     Ok(Json(true))
@@ -479,28 +582,37 @@ pub async fn union(
     let mork_api_client = MorkApiClient::new();
     let broadcaster = state.broadcaster.clone();
 
-    tokio::spawn(async move {
-        let _ = broadcaster.send("PROCESS_STARTED:UNION".to_string());
-        let _ = broadcaster.send("Starting union operation...".to_string());
+    JobRunner::spawn(
+        "UNION",
+        broadcaster.clone(),
+        move |tx: broadcast::Sender<ServerEvent>| {
+            let client = mork_api_client;
+            let path = request_path;
+            async move {
+                let _ = tx.send(ServerEvent::Log {
+                    message: "Starting union operation...".to_string(),
+                });
 
-        for transform_input in transform_inputs {
-            let request = TransformRequest::new().transform_input(transform_input);
+                for transform_input in transform_inputs {
+                    let request = TransformRequest::new().transform_input(transform_input);
 
-            if execute_polling_job(
-                &mork_api_client,
-                &broadcaster,
-                request,
-                request_path.clone(),
-                "Transform dispatched successfully.".to_string(),
-            )
-            .await
-            .is_err()
-            {
-                return;
+                    match client.dispatch(request).await {
+                        Ok(_) => {
+                            let _ = tx.send(ServerEvent::Log {
+                                message: "Transform dispatched successfully.".to_string(),
+                            });
+                        }
+                        Err(e) => return Err(format!("Error dispatching request: {:?}", e)),
+                    }
+
+                    if let Err(e) = poll_and_broadcast(path.clone(), &client, &tx).await {
+                        return Err(format!("Error polling status: {:?}", e));
+                    }
+                }
+                Ok("Union complete".to_string())
             }
-        }
-        let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
-    });
+        },
+    );
 
     Ok(Json(true))
 }
@@ -509,75 +621,10 @@ pub async fn union(
 ////////////////////////////////////////////// HELPER FUNCTIONS ////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-async fn execute_polling_job<R>(
-    mork_api_client: &MorkApiClient,
-    broadcaster: &broadcast::Sender<String>,
-    request: R,
-    request_path: PathBuf,
-    dispatch_msg: String,
-) -> Result<(), ()>
-where
-    R: Request + Send + Sync,
-{
-    match mork_api_client.dispatch(request).await {
-        Ok(_) => {
-            let _ = broadcaster.send(dispatch_msg);
-        }
-        Err(e) => {
-            let _ = broadcaster.send(format!("Error dispatching request: {:?}", e));
-            let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-            return Err(());
-        }
-    };
-
-    // poll status endpoint
-    match poll_and_broadcast(request_path, mork_api_client, broadcaster).await {
-        Ok(_) => {
-            let _ = broadcaster.send("Poll successful.".to_string());
-            Ok(())
-        }
-        Err(e) => {
-            let _ = broadcaster.send(format!("Error polling status: {:?}", e));
-            let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
-            Err(())
-        }
-    }
-}
-
-fn spawn_polling_job<R>(
-    broadcaster: broadcast::Sender<String>,
-    mork_api_client: MorkApiClient,
-    request: R,
-    request_path: PathBuf,
-    command_type: String,
-    start_msg: String,
-    dispatch_msg: String,
-) where
-    R: Request + Send + Sync + 'static,
-{
-    tokio::spawn(async move {
-        let _ = broadcaster.send(format!("PROCESS_STARTED:{}", command_type));
-        let _ = broadcaster.send(start_msg);
-
-        if execute_polling_job(
-            &mork_api_client,
-            &broadcaster,
-            request,
-            request_path,
-            dispatch_msg,
-        )
-        .await
-        .is_ok()
-        {
-            let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
-        }
-    });
-}
-
 async fn poll_and_broadcast(
     path: PathBuf,
     mork_api_client: &MorkApiClient,
-    broadcaster: &broadcast::Sender<String>,
+    broadcaster: &broadcast::Sender<ServerEvent>,
 ) -> Result<bool, Status> {
     let start_time = Instant::now();
     let timeout_duration = Duration::from_secs(300);
@@ -598,7 +645,9 @@ async fn poll_and_broadcast(
         sleep(Duration::from_millis(1000)).await;
 
         if counter % 5 == 0 {
-            let _ = broadcaster.send("Checking status...".to_string());
+            let _ = broadcaster.send(ServerEvent::Log {
+                message: "Checking status...".to_string(),
+            });
         }
         counter += 1;
 

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -311,19 +311,52 @@ pub async fn export(
 }
 
 #[post("/spaces/clear/<path..>?<expr>")]
-pub async fn clear(token: Token, path: PathBuf, expr: String) -> Result<Json<bool>, Status> {
+pub async fn clear(
+    token: Token,
+    path: PathBuf,
+    expr: String,
+    state: &State<CommandState>,
+) -> Result<Json<bool>, Status> {
     let token_namespace = token.namespace.strip_prefix("/").unwrap();
     if !path.starts_with(token_namespace) || !token.permission_write {
         return Err(Status::Unauthorized);
     }
 
     let mork_api_client = MorkApiClient::new();
-    let request = ClearRequest::new().namespace(path).expr(expr);
+    let request = ClearRequest::new().namespace(path.clone()).expr(expr);
 
-    match mork_api_client.dispatch(request).await {
-        Ok(_) => Ok(Json(true)),
-        Err(e) => Err(e),
-    }
+    let broadcaster = state.broadcaster.clone();
+    let request_path = path.clone();
+
+    tokio::spawn(async move {
+        let _ = broadcaster.send("PROCESS_STARTED".to_string());
+        let _ = broadcaster.send("Starting clear operation...".to_string());
+
+        match mork_api_client.dispatch(request).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Clear dispatched successfully.".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error dispatching clear: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+                return;
+            }
+        };
+
+        // poll status endpoint
+        match poll_and_broadcast(request_path, &mork_api_client, &broadcaster).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Poll successful.".to_string());
+                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+            }
+        }
+    });
+
+    Ok(Json(true))
 }
 
 /// Performs a transformation operation on the `<path..>` space

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -185,23 +185,20 @@ pub async fn upload(
             let client = mork_api_client;
             let req = request;
             async move {
+                client
+                    .dispatch(req)
+                    .await
+                    .map_err(|e| format!("Upload dispatch failed: {:?}", e))?;
+
                 let _ = tx.send(ServerEvent::Log {
-                    message: "Starting upload operation...".to_string(),
+                    message: "Data received, waiting for processing...".to_string(),
                 });
-                match client.dispatch(req).await {
-                    Ok(_) => {
-                        let _ = tx.send(ServerEvent::Log {
-                            message: "Upload dispatched successfully.".to_string(),
-                        });
-                    }
-                    Err(e) => {
-                        return Err(format!("Error dispatching request: {:?}", e));
-                    }
-                }
-                match poll_and_broadcast(request_path, &client, &tx).await {
-                    Ok(_) => Ok("Poll successful.".to_string()),
-                    Err(e) => Err(format!("Error polling status: {:?}", e)),
-                }
+
+                poll_and_broadcast(request_path, &client, &tx)
+                    .await
+                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
+
+                Ok("File uploaded and processed successfully".to_string())
             }
         },
     );
@@ -240,23 +237,20 @@ pub async fn import(
             let client = mork_api_client;
             let req = request;
             async move {
+                client
+                    .dispatch(req)
+                    .await
+                    .map_err(|e| format!("Import dispatch failed: {:?}", e))?;
+
                 let _ = tx.send(ServerEvent::Log {
-                    message: "Starting import operation...".to_string(),
+                    message: "Data received, waiting for processing...".to_string(),
                 });
-                match client.dispatch(req).await {
-                    Ok(_) => {
-                        let _ = tx.send(ServerEvent::Log {
-                            message: "Import dispatched successfully.".to_string(),
-                        });
-                    }
-                    Err(e) => {
-                        return Err(format!("Error dispatching request: {:?}", e));
-                    }
-                }
-                match poll_and_broadcast(request_path, &client, &tx).await {
-                    Ok(_) => Ok("Poll successful.".to_string()),
-                    Err(e) => Err(format!("Error polling status: {:?}", e)),
-                }
+
+                poll_and_broadcast(request_path, &client, &tx)
+                    .await
+                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
+
+                Ok("Import completed successfully.".to_string())
             }
         },
     );
@@ -375,23 +369,20 @@ pub async fn clear(
             let client = mork_api_client;
             let req = request;
             async move {
+                client
+                    .dispatch(req)
+                    .await
+                    .map_err(|e| format!("Clear dispatch failed: {:?}", e))?;
+
                 let _ = tx.send(ServerEvent::Log {
-                    message: "Starting clear operation...".to_string(),
+                    message: "Data received, waiting for processing...".to_string(),
                 });
-                match client.dispatch(req).await {
-                    Ok(_) => {
-                        let _ = tx.send(ServerEvent::Log {
-                            message: "Clear dispatched successfully.".to_string(),
-                        });
-                    }
-                    Err(e) => {
-                        return Err(format!("Error dispatching request: {:?}", e));
-                    }
-                }
-                match poll_and_broadcast(request_path, &client, &tx).await {
-                    Ok(_) => Ok("Poll successful.".to_string()),
-                    Err(e) => Err(format!("Error polling status: {:?}", e)),
-                }
+
+                poll_and_broadcast(request_path, &client, &tx)
+                    .await
+                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
+
+                Ok("Clear completed successfully.".to_string())
             }
         },
     );
@@ -437,23 +428,20 @@ pub async fn transform(
             let client = mork_api_client;
             let req = request;
             async move {
+                client
+                    .dispatch(req)
+                    .await
+                    .map_err(|e| format!("Transform dispatch failed: {:?}", e))?;
+
                 let _ = tx.send(ServerEvent::Log {
-                    message: "Starting transform operation...".to_string(),
+                    message: "Data received, waiting for processing...".to_string(),
                 });
-                match client.dispatch(req).await {
-                    Ok(_) => {
-                        let _ = tx.send(ServerEvent::Log {
-                            message: "Transform dispatched successfully.".to_string(),
-                        });
-                    }
-                    Err(e) => {
-                        return Err(format!("Error dispatching request: {:?}", e));
-                    }
-                }
-                match poll_and_broadcast(path_buf, &client, &tx).await {
-                    Ok(_) => Ok("Poll successful.".to_string()),
-                    Err(e) => Err(format!("Error polling status: {:?}", e)),
-                }
+
+                poll_and_broadcast(path_buf, &client, &tx)
+                    .await
+                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
+
+                Ok("Transform completed successfully.".to_string())
             }
         },
     );
@@ -506,23 +494,20 @@ pub async fn composition(
             let client = mork_api_client;
             let req = request;
             async move {
+                client
+                    .dispatch(req)
+                    .await
+                    .map_err(|e| format!("Composition dispatch failed: {:?}", e))?;
+
                 let _ = tx.send(ServerEvent::Log {
-                    message: "Starting composition operation...".to_string(),
+                    message: "Data received, waiting for processing...".to_string(),
                 });
-                match client.dispatch(req).await {
-                    Ok(_) => {
-                        let _ = tx.send(ServerEvent::Log {
-                            message: "Composition dispatched successfully.".to_string(),
-                        });
-                    }
-                    Err(e) => {
-                        return Err(format!("Error dispatching request: {:?}", e));
-                    }
-                }
-                match poll_and_broadcast(request_path, &client, &tx).await {
-                    Ok(_) => Ok("Poll successful.".to_string()),
-                    Err(e) => Err(format!("Error polling status: {:?}", e)),
-                }
+
+                poll_and_broadcast(request_path, &client, &tx)
+                    .await
+                    .map_err(|e| format!("Processing timeout: {:?}", e))?;
+
+                Ok("Composition completed successfully.".to_string())
             }
         },
     );
@@ -596,18 +581,18 @@ pub async fn union(
                 for transform_input in transform_inputs {
                     let request = TransformRequest::new().transform_input(transform_input);
 
-                    match client.dispatch(request).await {
-                        Ok(_) => {
-                            let _ = tx.send(ServerEvent::Log {
-                                message: "Transform dispatched successfully.".to_string(),
-                            });
-                        }
-                        Err(e) => return Err(format!("Error dispatching request: {:?}", e)),
-                    }
+                    client
+                        .dispatch(request)
+                        .await
+                        .map_err(|e| format!("Transformation dispatch failed: {:?}", e))?;
 
-                    if let Err(e) = poll_and_broadcast(path.clone(), &client, &tx).await {
-                        return Err(format!("Error polling status: {:?}", e));
-                    }
+                    let _ = tx.send(ServerEvent::Log {
+                        message: "Data received, waiting for processing...".to_string(),
+                    });
+
+                    poll_and_broadcast(path.clone(), &client, &tx)
+                        .await
+                        .map_err(|e| format!("Processing timeout: {:?}", e))?;
                 }
                 Ok("Union complete".to_string())
             }

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -145,7 +145,8 @@ pub async fn upload(
     token: Token,
     path: PathBuf,
     data: Data<'_>,
-) -> Result<Json<String>, Custom<String>> {
+    state: &State<CommandState>,
+) -> Result<Json<bool>, Custom<String>> {
     let token_namespace = token.namespace.strip_prefix("/").unwrap();
     if !path.starts_with(token_namespace) || !token.permission_write {
         return Err(Custom(Status::Unauthorized, "Unauthorized".to_string()));
@@ -168,23 +169,53 @@ pub async fn upload(
 
     let mork_api_client = MorkApiClient::new();
     let request = UploadRequest::new()
-        .namespace(path)
+        .namespace(path.clone())
         .pattern(pattern.to_string())
         .template(template.to_string())
         .data(body);
 
-    match mork_api_client.dispatch(request).await {
-        Ok(text) => Ok(Json(text)),
-        Err(e) => Err(Custom(
-            Status::InternalServerError,
-            format!("Failed to contact backend: {e}"),
-        )),
-    }
+    let broadcaster = state.broadcaster.clone();
+    let request_path = path;
+
+    tokio::spawn(async move {
+        let _ = broadcaster.send("PROCESS_STARTED".to_string());
+        let _ = broadcaster.send("Starting upload operation...".to_string());
+
+        match mork_api_client.dispatch(request).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Upload dispatched successfully.".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error dispatching upload: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+                return;
+            }
+        };
+
+        // poll status endpoint
+        match poll_and_broadcast(request_path, &mork_api_client, &broadcaster).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Poll successful.".to_string());
+                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+            }
+        }
+    });
+
+    Ok(Json(true))
 }
 
 /// Imports data from `<uri>` into the `<path..>` space. Exectes mm2 on the imported data.
 #[post("/spaces/import/<path..>?<uri>")]
-pub async fn import(token: Token, path: PathBuf, uri: String) -> Result<Json<bool>, Status> {
+pub async fn import(
+    token: Token,
+    path: PathBuf,
+    uri: String,
+    state: &State<CommandState>,
+) -> Result<Json<bool>, Status> {
     if !path.starts_with(token.namespace.strip_prefix("/").unwrap()) || !token.permission_write {
         return Err(Status::Unauthorized);
     }
@@ -195,13 +226,41 @@ pub async fn import(token: Token, path: PathBuf, uri: String) -> Result<Json<boo
     }
 
     let mork_api_client = MorkApiClient::new();
-    let template = Mm2Cell::new_template("$x".to_string(), Namespace::from(path));
+    let template = Mm2Cell::new_template("$x".to_string(), Namespace::from(path.clone()));
     let request = ImportRequest::new().to(template).uri(uri);
 
-    match mork_api_client.dispatch(request).await {
-        Ok(_) => Ok(Json(true)),
-        Err(e) => Err(e),
-    }
+    let broadcaster = state.broadcaster.clone();
+    let request_path = path.clone();
+
+    tokio::spawn(async move {
+        let _ = broadcaster.send("PROCESS_STARTED".to_string());
+        let _ = broadcaster.send("Starting import operation...".to_string());
+
+        match mork_api_client.dispatch(request).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Import dispatched successfully.".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error dispatching import: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+                return;
+            }
+        };
+
+        // poll status endpoint
+        match poll_and_broadcast(request_path, &mork_api_client, &broadcaster).await {
+            Ok(_) => {
+                let _ = broadcaster.send("Poll successful.".to_string());
+                let _ = broadcaster.send("PROCESS_EXIT_SUCCESS".to_string());
+            }
+            Err(e) => {
+                let _ = broadcaster.send(format!("Error polling status: {:?}", e));
+                let _ = broadcaster.send("PROCESS_EXIT_ERROR".to_string());
+            }
+        }
+    });
+
+    Ok(Json(true))
 }
 
 /// Performs an explore operation on the `<path..>` space. Get the result that
@@ -496,13 +555,14 @@ async fn poll_and_broadcast(
     broadcaster: &broadcast::Sender<String>,
 ) -> Result<bool, Status> {
     let start_time = Instant::now();
-    let timeout_duration = Duration::from_secs(40);
+    let timeout_duration = Duration::from_secs(300);
 
     // Check if space is clear by using status endpoint
     let check_request = StatusRequest::new()
         .namespace(path.clone())
         .pattern("$x".to_string());
 
+    let mut counter = 0;
     loop {
         // exit condition stop polling after some second
         if start_time.elapsed() > timeout_duration {
@@ -511,7 +571,11 @@ async fn poll_and_broadcast(
 
         // wait 1 second between each status request
         sleep(Duration::from_millis(1000)).await;
-        let _ = broadcaster.send("Checking status...".to_string());
+
+        if counter % 5 == 0 {
+            let _ = broadcaster.send("Checking status...".to_string());
+        }
+        counter += 1;
 
         // destructure status endpoint json response
         let status_response: StatusResponse =

--- a/api/src/routes/sse.rs
+++ b/api/src/routes/sse.rs
@@ -1,3 +1,4 @@
+use crate::sse_utils::ServerEvent;
 use rocket::fairing::AdHoc;
 use rocket::futures::stream::{self as futures_stream};
 use rocket::response::stream::{Event, EventStream};
@@ -7,7 +8,7 @@ use tokio::sync::broadcast;
 
 #[derive(Clone)]
 pub struct SseState {
-    pub broadcaster: broadcast::Sender<String>,
+    pub broadcaster: broadcast::Sender<ServerEvent>,
 }
 
 #[get("/events")]
@@ -16,7 +17,7 @@ pub fn stream(state: &State<SseState>) -> EventStream<impl rocket::futures::Stre
 
     let stream = futures_stream::unfold(rx, |mut rx| async move {
         match rx.recv().await {
-            Ok(msg) => Some((Event::data(msg), rx)),
+            Ok(msg) => Some((Event::from(msg), rx)),
             Err(_) => None,
         }
     });
@@ -26,7 +27,7 @@ pub fn stream(state: &State<SseState>) -> EventStream<impl rocket::futures::Stre
 
 pub fn stage() -> AdHoc {
     AdHoc::on_ignite("SSE Processor", |rocket| async {
-        let (tx_bc, _) = broadcast::channel::<String>(100);
+        let (tx_bc, _) = broadcast::channel::<ServerEvent>(100);
 
         rocket
             .manage(SseState { broadcaster: tx_bc })

--- a/api/src/routes/sse.rs
+++ b/api/src/routes/sse.rs
@@ -6,14 +6,12 @@ use rocket::{get, routes};
 use tokio::sync::broadcast;
 
 #[derive(Clone)]
-pub struct CommandState {
+pub struct SseState {
     pub broadcaster: broadcast::Sender<String>,
 }
 
 #[get("/events")]
-pub fn stream(
-    state: &State<CommandState>,
-) -> EventStream<impl rocket::futures::Stream<Item = Event>> {
+pub fn stream(state: &State<SseState>) -> EventStream<impl rocket::futures::Stream<Item = Event>> {
     let rx = state.broadcaster.subscribe();
 
     let stream = futures_stream::unfold(rx, |mut rx| async move {
@@ -27,14 +25,11 @@ pub fn stream(
 }
 
 pub fn stage() -> AdHoc {
-    AdHoc::on_ignite("Command Processor", |rocket| async {
+    AdHoc::on_ignite("SSE Processor", |rocket| async {
         let (tx_bc, _) = broadcast::channel::<String>(100);
 
         rocket
-            .manage(CommandState {
-                // sender: tx_cmd,
-                broadcaster: tx_bc,
-            })
+            .manage(SseState { broadcaster: tx_bc })
             .mount("/", routes![stream])
     })
 }

--- a/api/src/sse_utils.rs
+++ b/api/src/sse_utils.rs
@@ -1,0 +1,53 @@
+use rocket::response::stream::Event;
+use tokio::sync::broadcast::Sender;
+
+// Typed events for SSE;
+#[derive(Clone, Debug)]
+pub enum ServerEvent {
+    Started { command: String },
+    Log { message: String },
+    Success { message: String },
+    Error { message: String },
+}
+
+impl From<ServerEvent> for Event {
+    fn from(event: ServerEvent) -> Event {
+        match event {
+            ServerEvent::Started { command } => Event::data(format!("PROCESS_STARTED:{}", command)),
+            ServerEvent::Log { message } => Event::data(message),
+            ServerEvent::Success { .. } => Event::data("PROCESS_EXIT_SUCCESS"),
+            ServerEvent::Error { .. } => Event::data("PROCESS_EXIT_ERROR"),
+        }
+    }
+}
+
+pub struct JobRunner;
+
+impl JobRunner {
+    // Spawns a background job with standard lifecycle events.
+    pub fn spawn<F, Fut>(command_name: &str, broadcaster: Sender<ServerEvent>, task: F)
+    where
+        F: FnOnce(Sender<ServerEvent>) -> Fut + Send + 'static,
+        Fut: std::future::Future<Output = Result<String, String>> + Send,
+    {
+        let command = command_name.to_string();
+        tokio::spawn(async move {
+            let _ = broadcaster.send(ServerEvent::Started { command });
+
+            match task(broadcaster.clone()).await {
+                Ok(msg) => {
+                    let _ = broadcaster.send(ServerEvent::Log { message: msg });
+                    let _ = broadcaster.send(ServerEvent::Success {
+                        message: "Done".into(),
+                    });
+                }
+                Err(err) => {
+                    let _ = broadcaster.send(ServerEvent::Log {
+                        message: format!("Error: {}", err),
+                    });
+                    let _ = broadcaster.send(ServerEvent::Error { message: err });
+                }
+            }
+        });
+    }
+}

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,3 +1,5 @@
 node_modules
 dist
 .env
+res.rest
+cmds.txt

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -2,9 +2,25 @@ import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { API_URL } from "./api";
 
-export const [isCommandRunning, setIsCommandRunning] = createSignal(false);
+export type CommandType =
+  | "IMPORT"
+  | "EXPORT"
+  | "UNION"
+  | "TRANSFORM"
+  | "COMPOSITION"
+  | "CLEAR"
+  | "UPLOAD"
+  | "UNKNOWN"
+  | null;
+
+export const [activeCommand, setActiveCommand] =
+  createSignal<CommandType>(null);
 export const [commandProgress, setCommandProgress] = createSignal(0);
 export const [commandLogs, setCommandLogs] = createSignal<string[]>([]);
+
+export const isCommandActive = (type: CommandType) => activeCommand() === type;
+export const isAnyCommandActive = () => activeCommand() !== null;
+export const isCommandRunning = isAnyCommandActive;
 
 let eventSource: EventSource | null = null;
 
@@ -23,8 +39,11 @@ export const initSSE = () => {
     console.log("SSE Message Received:", event.data);
     const data = event.data;
 
-    if (data === "PROCESS_STARTED") {
-      setIsCommandRunning(true);
+    if (data.startsWith("PROCESS_STARTED")) {
+      const parts = data.split(":");
+      const commandType =
+        parts.length > 1 ? (parts[1] as CommandType) : "UNKNOWN";
+      setActiveCommand(commandType);
       setCommandProgress(0);
       setCommandLogs([]);
       return;
@@ -32,7 +51,7 @@ export const initSSE = () => {
 
     if (data === "PROCESS_EXIT_SUCCESS") {
       setCommandProgress(100);
-      setIsCommandRunning(false);
+      setActiveCommand(null);
       showToast({
         title: "Success",
         description: "Command completed successfully",
@@ -41,7 +60,7 @@ export const initSSE = () => {
     }
 
     if (data === "PROCESS_EXIT_ERROR") {
-      setIsCommandRunning(false);
+      setActiveCommand(null);
       showToast({
         title: "Error",
         description: "Command failed",

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -15,7 +15,12 @@ export const initSSE = () => {
   const eventsUrl = new URL("/events", API_URL).toString();
   eventSource = new EventSource(eventsUrl);
 
+  eventSource.onopen = () => {
+    console.log("SSE Connection Opened");
+  };
+
   eventSource.onmessage = (event) => {
+    console.log("SSE Message Received:", event.data);
     const data = event.data;
 
     if (data === "PROCESS_STARTED") {
@@ -48,12 +53,12 @@ export const initSSE = () => {
     // Handle stdout/stderr
     // If the message is not a lifecycle event, treat it as log output
     setCommandLogs((prev) => [...prev, data]);
-    
+
     // Increment progress (cap at 90%)
     // We use a functional update to ensure we're working with the latest value
     setCommandProgress((prev) => {
-        if (prev >= 90) return prev;
-        return prev + 5;
+      if (prev >= 90) return prev;
+      return prev + 5;
     });
   };
 

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -25,7 +25,15 @@ export const isCommandRunning = isAnyCommandActive;
 let eventSource: EventSource | null = null;
 
 export const initSSE = () => {
-  if (eventSource) return;
+
+  if (eventSource && (eventSource.readyState === 0 || eventSource.readyState === 1)) {
+    return;
+  }
+  
+  // Close any existing potentially closed/broken connection before making a new one
+  if (eventSource) {
+     eventSource.close();
+  }
 
   // Use API_URL to construct the full URL for the events endpoint
   const eventsUrl = new URL("/events", API_URL).toString();
@@ -50,20 +58,24 @@ export const initSSE = () => {
     }
 
     if (data === "PROCESS_EXIT_SUCCESS") {
+
+      const cmdName = activeCommand();
       setCommandProgress(100);
       setActiveCommand(null);
       showToast({
         title: "Success",
-        description: "Command completed successfully",
+        description: `${cmdName} completed successfully`,
       });
       return;
     }
 
     if (data === "PROCESS_EXIT_ERROR") {
+
+      const cmdName = activeCommand();
       setActiveCommand(null);
       showToast({
         title: "Error",
-        description: "Command failed",
+        description: `${cmdName} failed`,
         variant: "destructive",
       });
       return;

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -1,0 +1,64 @@
+import { createSignal } from "solid-js";
+import { showToast } from "~/components/ui/Toast";
+import { API_URL } from "./api";
+
+export const [isCommandRunning, setIsCommandRunning] = createSignal(false);
+export const [commandProgress, setCommandProgress] = createSignal(0);
+export const [commandLogs, setCommandLogs] = createSignal<string[]>([]);
+
+let eventSource: EventSource | null = null;
+
+export const initSSE = () => {
+  if (eventSource) return;
+
+  // Use API_URL to construct the full URL for the events endpoint
+  const eventsUrl = new URL("/events", API_URL).toString();
+  eventSource = new EventSource(eventsUrl);
+
+  eventSource.onmessage = (event) => {
+    const data = event.data;
+
+    if (data === "PROCESS_STARTED") {
+      setIsCommandRunning(true);
+      setCommandProgress(0);
+      setCommandLogs([]);
+      return;
+    }
+
+    if (data === "PROCESS_EXIT_SUCCESS") {
+      setCommandProgress(100);
+      setIsCommandRunning(false);
+      showToast({
+        title: "Success",
+        description: "Command completed successfully",
+      });
+      return;
+    }
+
+    if (data === "PROCESS_EXIT_ERROR") {
+      setIsCommandRunning(false);
+      showToast({
+        title: "Error",
+        description: "Command failed",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    // Handle stdout/stderr
+    // If the message is not a lifecycle event, treat it as log output
+    setCommandLogs((prev) => [...prev, data]);
+    
+    // Increment progress (cap at 90%)
+    // We use a functional update to ensure we're working with the latest value
+    setCommandProgress((prev) => {
+        if (prev >= 90) return prev;
+        return prev + 5;
+    });
+  };
+
+  eventSource.onerror = (err) => {
+    console.error("SSE Error:", err);
+    // EventSource will attempt to reconnect automatically
+  };
+};

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -95,10 +95,10 @@ export const initSSE = () => {
 
   eventSource.onerror = (err) => {
     showToast({
-        title: "Error",
-        description: `Error in SSE connection, attempting to reconnect...`,
-        variant: "destructive",
-      });
+      title: "Error",
+      description: `Error in SSE connection, attempting to reconnect...`,
+      variant: "destructive",
+    });
     console.error("SSE Error:", err);
     // EventSource will attempt to reconnect automatically
   };

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -25,14 +25,16 @@ export const isCommandRunning = isAnyCommandActive;
 let eventSource: EventSource | null = null;
 
 export const initSSE = () => {
-
-  if (eventSource && (eventSource.readyState === 0 || eventSource.readyState === 1)) {
+  if (
+    eventSource &&
+    (eventSource.readyState === 0 || eventSource.readyState === 1)
+  ) {
     return;
   }
-  
+
   // Close any existing potentially closed/broken connection before making a new one
   if (eventSource) {
-     eventSource.close();
+    eventSource.close();
   }
 
   // Use API_URL to construct the full URL for the events endpoint
@@ -58,7 +60,6 @@ export const initSSE = () => {
     }
 
     if (data === "PROCESS_EXIT_SUCCESS") {
-
       const cmdName = activeCommand();
       setCommandProgress(100);
       setActiveCommand(null);
@@ -70,7 +71,6 @@ export const initSSE = () => {
     }
 
     if (data === "PROCESS_EXIT_ERROR") {
-
       const cmdName = activeCommand();
       setActiveCommand(null);
       showToast({

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -94,6 +94,11 @@ export const initSSE = () => {
   };
 
   eventSource.onerror = (err) => {
+    showToast({
+        title: "Error",
+        description: `Error in SSE connection, attempting to reconnect...`,
+        variant: "destructive",
+      });
     console.error("SSE Error:", err);
     // EventSource will attempt to reconnect automatically
   };

--- a/frontend/src/pages/clear/lib.ts
+++ b/frontend/src/pages/clear/lib.ts
@@ -27,7 +27,7 @@ export const handleClear = async (spacePath: string) => {
       });
     }
 
-    refreshSpace()
+    refreshSpace();
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";

--- a/frontend/src/pages/clear/lib.ts
+++ b/frontend/src/pages/clear/lib.ts
@@ -27,6 +27,10 @@ export const handleClear = async (spacePath: string) => {
       });
     }
 
+    if (!isCommandRunning) {
+      refreshSpace();
+    }
+
     refreshSpace();
   } catch (error) {
     const errorMessage =

--- a/frontend/src/pages/clear/lib.ts
+++ b/frontend/src/pages/clear/lib.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { clearSpace } from "~/lib/api";
 import { isCommandRunning } from "~/lib/sse";
+import { refreshSpace } from "../load/lib";
 
 export const [expression, setExpression] = createSignal("$x \n \n \n");
 export { isCommandRunning as isLoading };
@@ -25,6 +26,8 @@ export const handleClear = async (spacePath: string) => {
         description: "Waiting for results...",
       });
     }
+
+    refreshSpace()
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";

--- a/frontend/src/pages/clear/lib.ts
+++ b/frontend/src/pages/clear/lib.ts
@@ -1,10 +1,10 @@
 import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { clearSpace } from "~/lib/api";
-import { refreshSpace } from "../load/lib";
+import { isCommandRunning } from "~/lib/sse";
 
 export const [expression, setExpression] = createSignal("$x \n \n \n");
-export const [isLoading, setIsLoading] = createSignal(false);
+export { isCommandRunning as isLoading };
 
 export const handleClear = async (spacePath: string) => {
   if (!expression().trim()) {
@@ -16,22 +16,13 @@ export const handleClear = async (spacePath: string) => {
     return;
   }
 
-  setIsLoading(true);
-
   try {
-    const success = await clearSpace(expression(), spacePath);
+    const initiated = await clearSpace(expression(), spacePath);
 
-    if (success) {
+    if (initiated) {
       showToast({
-        title: "Cleared Successfully",
-        description: `Space "${spacePath}" has been cleared.`,
-      });
-      refreshSpace();
-    } else {
-      showToast({
-        title: "Clear Operation Failed",
-        description: `Could not clear space "${spacePath}". Check server logs for details.`,
-        variant: "destructive",
+        title: "Clear Initiated",
+        description: "Waiting for results...",
       });
     }
   } catch (error) {
@@ -42,7 +33,5 @@ export const handleClear = async (spacePath: string) => {
       description: errorMessage,
       variant: "destructive",
     });
-  } finally {
-    setIsLoading(false);
   }
 };

--- a/frontend/src/pages/clear/lib.ts
+++ b/frontend/src/pages/clear/lib.ts
@@ -27,10 +27,6 @@ export const handleClear = async (spacePath: string) => {
       });
     }
 
-    if (!isCommandRunning) {
-      refreshSpace();
-    }
-
     refreshSpace();
   } catch (error) {
     const errorMessage =

--- a/frontend/src/pages/composition/Composition.tsx
+++ b/frontend/src/pages/composition/Composition.tsx
@@ -13,6 +13,7 @@ import { getAllTokens } from "~/lib/api";
 import { rootToken, tokenRootNamespace } from "~/lib/state";
 import {
   isLoading,
+  isAppBusy,
   isPolling,
   executeComposition,
   stopPolling,
@@ -202,7 +203,7 @@ const CompositionPage: Component = () => {
 
         <Button
           onClick={handleComposition}
-          disabled={isLoading() || isPolling() || !canCompose()}
+          disabled={isAppBusy() || !canCompose()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>

--- a/frontend/src/pages/composition/Composition.tsx
+++ b/frontend/src/pages/composition/Composition.tsx
@@ -9,7 +9,6 @@ import {
   CardDescription,
   CardContent,
 } from "~/components/ui/Card";
-import { formatedNamespace } from "~/lib/state";
 import { getAllTokens } from "~/lib/api";
 import { rootToken, tokenRootNamespace } from "~/lib/state";
 import {
@@ -80,7 +79,7 @@ const CompositionPage: Component = () => {
   const handleComposition = () => {
     const compositionQueryInput: setOperationInput =
       buildCompositionSetInput(state);
-    executeComposition(compositionQueryInput, formatedNamespace());
+    executeComposition(compositionQueryInput);
   };
 
   const addSource = () => {

--- a/frontend/src/pages/composition/lib.ts
+++ b/frontend/src/pages/composition/lib.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import { composition } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
 import { isCommandRunning } from "~/lib/sse";
+import { refreshSpace } from "../load/lib";
 
 export { isCommandRunning as isLoading };
 export const [isPolling, setIsPolling] = createSignal(false);
@@ -43,6 +44,8 @@ export const executeComposition = async (
     });
 
     await composition(compositionQuery);
+
+    refreshSpace()
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";

--- a/frontend/src/pages/composition/lib.ts
+++ b/frontend/src/pages/composition/lib.ts
@@ -45,7 +45,7 @@ export const executeComposition = async (
 
     await composition(compositionQuery);
 
-    refreshSpace()
+    refreshSpace();
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";

--- a/frontend/src/pages/composition/lib.ts
+++ b/frontend/src/pages/composition/lib.ts
@@ -1,10 +1,11 @@
 import { createSignal } from "solid-js";
 import { composition } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
-import { isCommandRunning } from "~/lib/sse";
+import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
 
-export { isCommandRunning as isLoading };
+export const isLoading = () => isCommandActive("COMPOSITION");
+export const isAppBusy = isAnyCommandActive;
 export const [isPolling, setIsPolling] = createSignal(false);
 
 export type setOperationInput = {

--- a/frontend/src/pages/composition/lib.ts
+++ b/frontend/src/pages/composition/lib.ts
@@ -16,8 +16,7 @@ export const stopPolling = () => {
 };
 
 export const executeComposition = async (
-  compositionQuery: setOperationInput,
-  _spacePath: string
+  compositionQuery: setOperationInput
 ) => {
   if (compositionQuery.source.length < 2) {
     showToast({

--- a/frontend/src/pages/composition/lib.ts
+++ b/frontend/src/pages/composition/lib.ts
@@ -1,50 +1,23 @@
 import { createSignal } from "solid-js";
-import { composition, isPathClear } from "~/lib/api";
+import { composition } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
-import { refreshSpace } from "../load/lib";
+import { isCommandRunning } from "~/lib/sse";
 
-export const [isLoading, setIsLoading] = createSignal(false);
+export { isCommandRunning as isLoading };
 export const [isPolling, setIsPolling] = createSignal(false);
 
 export type setOperationInput = {
   source: string[];
   target: string[];
 };
-let pollingIntervalId: NodeJS.Timeout | null = null;
 
 export const stopPolling = () => {
-  if (pollingIntervalId) clearInterval(pollingIntervalId);
-  pollingIntervalId = null;
   setIsPolling(false);
-};
-
-export const startPolling = (spacePath: string) => {
-  setIsPolling(true);
-  pollingIntervalId = setInterval(async () => {
-    try {
-      const isClear = await isPathClear(spacePath);
-      if (isClear) {
-        stopPolling();
-        showToast({
-          title: "Composition Completed",
-          description: "successfully completed composition operation",
-        });
-        refreshSpace();
-      }
-    } catch {
-      showToast({
-        title: "Polling Error",
-        description: "Failed to fetch composition status.",
-        variant: "destructive",
-      });
-      stopPolling();
-    }
-  }, 3000);
 };
 
 export const executeComposition = async (
   compositionQuery: setOperationInput,
-  spacePath: string
+  _spacePath: string
 ) => {
   if (compositionQuery.source.length < 2) {
     showToast({
@@ -64,34 +37,13 @@ export const executeComposition = async (
     return;
   }
 
-  setIsLoading(true);
-  stopPolling();
   try {
-    if (!(await isPathClear(spacePath))) {
-      showToast({
-        title: "Space Busy",
-        description: "The space is currently busy. Please wait.",
-        variant: "destructive",
-      });
-      setIsLoading(false);
-      return;
-    }
+    showToast({
+      title: "Composition Initiated",
+      description: "Waiting for results...",
+    });
 
-    const success = await composition(compositionQuery);
-
-    if (success) {
-      showToast({
-        title: "Composition Initiated",
-        description: "Waiting for results...",
-      });
-      startPolling(spacePath);
-    } else {
-      showToast({
-        title: "Composition Failed",
-        description: "Could not initiate the composition.",
-        variant: "destructive",
-      });
-    }
+    await composition(compositionQuery);
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";
@@ -100,7 +52,5 @@ export const executeComposition = async (
       description: errorMessage,
       variant: "destructive",
     });
-  } finally {
-    setIsLoading(false);
   }
 };

--- a/frontend/src/pages/export/Export.tsx
+++ b/frontend/src/pages/export/Export.tsx
@@ -18,6 +18,7 @@ import {
   format,
   setFormat,
   isLoading,
+  isAppBusy,
   pattern,
   setPattern,
   template,
@@ -76,7 +77,7 @@ const ExportPage: Component = () => {
               options={["metta", "json", "csv", "raw"]}
               value={format()}
               onChange={setFormat}
-              disabled={isLoading()}
+              disabled={isAppBusy()}
               placeholder="Select a format"
               itemComponent={(props) => (
                 <SelectItem item={props.item}>
@@ -97,7 +98,7 @@ const ExportPage: Component = () => {
         <div class="mt-4">
           <Button
             onClick={() => handleExport(formatedNamespace())}
-            disabled={isLoading() || !pattern().trim() || !template().trim()}
+            disabled={isAppBusy() || !pattern().trim() || !template().trim()}
             class="w-36"
           >
             <Show

--- a/frontend/src/pages/export/lib.ts
+++ b/frontend/src/pages/export/lib.ts
@@ -2,11 +2,12 @@ import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { exportSpace } from "~/lib/api";
 import { Mm2Input } from "~/lib/types";
-import { isCommandRunning } from "~/lib/sse";
+import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
 
 export const [uri, setUri] = createSignal("");
 export const [format, setFormat] = createSignal("metta");
-export { isCommandRunning as isLoading };
+export const isLoading = () => isCommandActive("EXPORT");
+export const isAppBusy = isAnyCommandActive;
 export const [pattern, setPattern] = createSignal("$x\n\n\n");
 export const [template, setTemplate] = createSignal("$x\n\n\n");
 export const [result, setResult] = createSignal<string | null>(null);

--- a/frontend/src/pages/export/lib.ts
+++ b/frontend/src/pages/export/lib.ts
@@ -2,10 +2,11 @@ import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { exportSpace } from "~/lib/api";
 import { Mm2Input } from "~/lib/types";
+import { isCommandRunning } from "~/lib/sse";
 
 export const [uri, setUri] = createSignal("");
 export const [format, setFormat] = createSignal("metta");
-export const [isLoading, setIsLoading] = createSignal(false);
+export { isCommandRunning as isLoading };
 export const [pattern, setPattern] = createSignal("$x\n\n\n");
 export const [template, setTemplate] = createSignal("$x\n\n\n");
 export const [result, setResult] = createSignal<string | null>(null);
@@ -17,7 +18,6 @@ export const handleExport = async (spacePath: string) => {
     template: template().trim() || "$x",
   };
 
-  setIsLoading(true);
   setResult(null);
   setExportError(null);
 
@@ -45,7 +45,5 @@ export const handleExport = async (spacePath: string) => {
       description: error.message,
       variant: "destructive",
     });
-  } finally {
-    setIsLoading(false);
   }
 };

--- a/frontend/src/pages/index/Index.tsx
+++ b/frontend/src/pages/index/Index.tsx
@@ -162,7 +162,7 @@ const AppLayout = (
         <Show when={isCommandRunning()}>
           <div class="w-full h-1 bg-gray-200">
             <div
-              class="h-full bg-blue-500 transition-all duration-300"
+              class="h-full bg-green-500 transition-all duration-300"
               style={{ width: `${commandProgress()}%` }}
             ></div>
           </div>

--- a/frontend/src/pages/index/Index.tsx
+++ b/frontend/src/pages/index/Index.tsx
@@ -1,5 +1,5 @@
 import { Route, Router } from "@solidjs/router";
-import { createSignal, For } from "solid-js";
+import { createSignal, For, Show, onMount } from "solid-js";
 import LoadPage from "../load/Load";
 import UploadPage from "../upload/Upload";
 import TransformPage from "../transform/Transform";
@@ -19,6 +19,7 @@ import NotImplemented from "~/components/common/NotImplemented";
 import Trash2 from "lucide-solid/icons/trash-2";
 import CommandPalette from "~/components/common/CommandPalette";
 import UnionPage from "../union/Union";
+import { initSSE, isCommandRunning, commandProgress } from "~/lib/sse";
 
 export const sidebarSections = [
   {
@@ -157,7 +158,15 @@ const AppLayout = (
                         </div>
                     </div>
                 </div> */}
-          <Header />
+        <Header />
+        <Show when={isCommandRunning()}>
+          <div class="w-full h-1 bg-gray-200">
+            <div
+              class="h-full bg-blue-500 transition-all duration-300"
+              style={{ width: `${commandProgress()}%` }}
+            ></div>
+          </div>
+        </Show>
 
           <div class="flex-1 w-full pl-4 pt-2 overflow-y-scroll">
             {props.children}
@@ -173,6 +182,10 @@ const NotImplementedWrapper = (name: string) => () => (
 );
 
 const App = () => {
+  onMount(() => {
+    initSSE();
+  });
+
   return (
     <div class="flex">
       <div class="flex-1 flex flex-col">

--- a/frontend/src/pages/load/lib.ts
+++ b/frontend/src/pages/load/lib.ts
@@ -1,9 +1,15 @@
-import { createSignal, createResource } from "solid-js";
+import {
+  createSignal,
+  createResource,
+  createRoot,
+  createEffect,
+} from "solid-js";
 import { formatedNamespace } from "~/lib/state";
 import { ParseError } from "~/types";
 import { exploreSpace } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
 import { treeStore } from "./components/expandableList/store";
+import { isCommandRunning } from "~/lib/sse";
 
 type ExploreResponse = {
   id: string;
@@ -54,7 +60,20 @@ export const [subSpace, { refetch: refetchSubSpace, mutate: mutateSubSpace }] =
     }
   );
 
-export const refreshSpace = () => {
+export const refreshSpace = async () => {
+  // If a command is running, wait for it to finish
+  if (isCommandRunning()) {
+    await new Promise<void>((resolve) => {
+      createRoot((dispose) => {
+        createEffect(() => {
+          if (!isCommandRunning()) {
+            dispose();
+            resolve();
+          }
+        });
+      });
+    });
+  }
   mutateSubSpace([]);
   treeStore.reset();
   return refetchSubSpace();

--- a/frontend/src/pages/transform/Transform.tsx
+++ b/frontend/src/pages/transform/Transform.tsx
@@ -9,7 +9,6 @@ import {
   CardDescription,
   CardContent,
 } from "~/components/ui/Card";
-import { formatedNamespace } from "~/lib/state";
 import { getAllTokens } from "~/lib/api";
 import { rootToken, tokenRootNamespace } from "~/lib/state";
 import { isLoading, isPolling, executeTransform, stopPolling } from "./lib";

--- a/frontend/src/pages/transform/Transform.tsx
+++ b/frontend/src/pages/transform/Transform.tsx
@@ -174,7 +174,7 @@ const TransformPage: Component = () => {
 
         <Button
           onClick={handleTransform}
-          disabled={isAppBusy() || isPolling()}
+          disabled={isAppBusy() || isPolling() || !canTransform()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>

--- a/frontend/src/pages/transform/Transform.tsx
+++ b/frontend/src/pages/transform/Transform.tsx
@@ -34,7 +34,7 @@ const TransformPage: Component = () => {
   };
 
   const handleTransform = () => {
-    executeTransform(state.patterns, state.templates, formatedNamespace());
+    executeTransform(state.patterns, state.templates);
   };
 
   const addPattern = () => {

--- a/frontend/src/pages/transform/Transform.tsx
+++ b/frontend/src/pages/transform/Transform.tsx
@@ -174,7 +174,7 @@ const TransformPage: Component = () => {
 
         <Button
           onClick={handleTransform}
-          disabled={isAppBusy() || isPolling() || !canTransform()}
+          disabled={isAppBusy() || isPolling()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>

--- a/frontend/src/pages/transform/Transform.tsx
+++ b/frontend/src/pages/transform/Transform.tsx
@@ -174,7 +174,7 @@ const TransformPage: Component = () => {
 
         <Button
           onClick={handleTransform}
-          disabled={isLoading() || isPolling() || !canTransform()}
+          disabled={isAppBusy() || isPolling() || !canTransform()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>

--- a/frontend/src/pages/transform/lib.ts
+++ b/frontend/src/pages/transform/lib.ts
@@ -2,10 +2,11 @@ import { createSignal } from "solid-js";
 import { transform } from "~/lib/api";
 import { Mm2InputMultiWithNamespace, Item } from "~/lib/types";
 import { showToast } from "~/components/ui/Toast";
-import { isCommandRunning } from "~/lib/sse";
+import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
 
-export { isCommandRunning as isLoading };
+export const isLoading = () => isCommandActive("TRANSFORM");
+export const isAppBusy = isAnyCommandActive;
 export const [isPolling, setIsPolling] = createSignal(false);
 
 export const stopPolling = () => {

--- a/frontend/src/pages/transform/lib.ts
+++ b/frontend/src/pages/transform/lib.ts
@@ -3,6 +3,7 @@ import { transform } from "~/lib/api";
 import { Mm2InputMultiWithNamespace, Item } from "~/lib/types";
 import { showToast } from "~/components/ui/Toast";
 import { isCommandRunning } from "~/lib/sse";
+import { refreshSpace } from "../load/lib";
 
 export { isCommandRunning as isLoading };
 export const [isPolling, setIsPolling] = createSignal(false);
@@ -44,6 +45,8 @@ export const executeTransform = async (patterns: Item[], templates: Item[]) => {
     });
 
     await transform(input);
+
+    refreshSpace()
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";

--- a/frontend/src/pages/transform/lib.ts
+++ b/frontend/src/pages/transform/lib.ts
@@ -46,7 +46,7 @@ export const executeTransform = async (patterns: Item[], templates: Item[]) => {
 
     await transform(input);
 
-    refreshSpace()
+    refreshSpace();
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";

--- a/frontend/src/pages/transform/lib.ts
+++ b/frontend/src/pages/transform/lib.ts
@@ -11,11 +11,7 @@ export const stopPolling = () => {
   setIsPolling(false);
 };
 
-export const executeTransform = async (
-  patterns: Item[],
-  templates: Item[],
-  _spacePath: string
-) => {
+export const executeTransform = async (patterns: Item[], templates: Item[]) => {
   if (
     !patterns.some((p) => p.value.trim()) ||
     !templates.some((t) => t.value.trim())

--- a/frontend/src/pages/transform/lib.ts
+++ b/frontend/src/pages/transform/lib.ts
@@ -1,48 +1,20 @@
 import { createSignal } from "solid-js";
-import { transform, isPathClear } from "~/lib/api";
+import { transform } from "~/lib/api";
 import { Mm2InputMultiWithNamespace, Item } from "~/lib/types";
 import { showToast } from "~/components/ui/Toast";
-import { refreshSpace } from "../load/lib";
+import { isCommandRunning } from "~/lib/sse";
 
-export const [isLoading, setIsLoading] = createSignal(false);
+export { isCommandRunning as isLoading };
 export const [isPolling, setIsPolling] = createSignal(false);
 
-let pollingIntervalId: NodeJS.Timeout | null = null;
-
 export const stopPolling = () => {
-  if (pollingIntervalId) clearInterval(pollingIntervalId);
-  pollingIntervalId = null;
   setIsPolling(false);
-};
-
-export const startPolling = (spacePath: string) => {
-  setIsPolling(true);
-  pollingIntervalId = setInterval(async () => {
-    try {
-      const isClear = await isPathClear(spacePath);
-      if (isClear) {
-        stopPolling();
-        showToast({
-          title: "Transform Completed",
-          description: "The space has been successfully transformed.",
-        });
-        refreshSpace();
-      }
-    } catch {
-      showToast({
-        title: "Polling Error",
-        description: "Failed to fetch transformation status.",
-        variant: "destructive",
-      });
-      stopPolling();
-    }
-  }, 3000);
 };
 
 export const executeTransform = async (
   patterns: Item[],
   templates: Item[],
-  spacePath: string
+  _spacePath: string
 ) => {
   if (
     !patterns.some((p) => p.value.trim()) ||
@@ -56,20 +28,7 @@ export const executeTransform = async (
     return;
   }
 
-  setIsLoading(true);
-  stopPolling();
-
   try {
-    if (!(await isPathClear(spacePath))) {
-      showToast({
-        title: "Space Busy",
-        description: "The space is currently busy. Please wait.",
-        variant: "destructive",
-      });
-      setIsLoading(false);
-      return;
-    }
-
     const input: Mm2InputMultiWithNamespace = {
       patterns: patterns.map((p) => ({
         kind: "pattern" as const,
@@ -82,21 +41,13 @@ export const executeTransform = async (
         namespace: t.namespace.filter((n) => n !== ""),
       })),
     };
-    const success = await transform(input);
 
-    if (success) {
-      showToast({
-        title: "Transform Initiated",
-        description: "Waiting for results...",
-      });
-      startPolling(spacePath);
-    } else {
-      showToast({
-        title: "Transform Failed",
-        description: "Could not initiate the transformation.",
-        variant: "destructive",
-      });
-    }
+    showToast({
+      title: "Transform Initiated",
+      description: "Waiting for results...",
+    });
+
+    await transform(input);
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";
@@ -105,7 +56,5 @@ export const executeTransform = async (
       description: errorMessage,
       variant: "destructive",
     });
-  } finally {
-    setIsLoading(false);
   }
 };

--- a/frontend/src/pages/union/Union.tsx
+++ b/frontend/src/pages/union/Union.tsx
@@ -13,6 +13,7 @@ import { getAllTokens } from "~/lib/api";
 import { rootToken, tokenRootNamespace } from "~/lib/state";
 import {
   isLoading,
+  isAppBusy,
   isPolling,
   executeUnion,
   stopPolling,
@@ -207,7 +208,7 @@ const UnionPage: Component = () => {
 
         <Button
           onClick={handleUnion}
-          disabled={isLoading() || isPolling() || !canUnion()}
+          disabled={isAppBusy() || isPolling() || !canUnion()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>

--- a/frontend/src/pages/union/Union.tsx
+++ b/frontend/src/pages/union/Union.tsx
@@ -208,7 +208,7 @@ const UnionPage: Component = () => {
 
         <Button
           onClick={handleUnion}
-          disabled={isAppBusy() || isPolling()}
+          disabled={isAppBusy() || isPolling() || !canUnion()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>

--- a/frontend/src/pages/union/Union.tsx
+++ b/frontend/src/pages/union/Union.tsx
@@ -208,7 +208,7 @@ const UnionPage: Component = () => {
 
         <Button
           onClick={handleUnion}
-          disabled={isAppBusy() || isPolling() || !canUnion()}
+          disabled={isAppBusy() || isPolling()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>

--- a/frontend/src/pages/union/Union.tsx
+++ b/frontend/src/pages/union/Union.tsx
@@ -9,7 +9,6 @@ import {
   CardDescription,
   CardContent,
 } from "~/components/ui/Card";
-import { formatedNamespace } from "~/lib/state";
 import { getAllTokens } from "~/lib/api";
 import { rootToken, tokenRootNamespace } from "~/lib/state";
 import {
@@ -78,7 +77,7 @@ const UnionPage: Component = () => {
 
   const handleUnion = () => {
     const unionQueryInput: setOperationInput = buildUnionSetInput(state);
-    executeUnion(unionQueryInput, formatedNamespace());
+    executeUnion(unionQueryInput);
   };
 
   const addPattern = () => {

--- a/frontend/src/pages/union/lib.ts
+++ b/frontend/src/pages/union/lib.ts
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js";
 import { union } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
-import { isCommandRunning, setIsCommandRunning } from "~/lib/sse";
+import { isCommandRunning } from "~/lib/sse";
 
 export { isCommandRunning as isLoading };
 export const [isPolling, setIsPolling] = createSignal(false);
@@ -17,7 +17,7 @@ export const stopPolling = () => {
 
 export const executeUnion = async (
   unionQuery: setOperationInput,
-  spacePath: string
+  _spacePath: string
 ) => {
   if (unionQuery.pattern.length < 1) {
     showToast({
@@ -44,7 +44,6 @@ export const executeUnion = async (
     });
 
     await union(unionQuery);
-
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";

--- a/frontend/src/pages/union/lib.ts
+++ b/frontend/src/pages/union/lib.ts
@@ -1,19 +1,17 @@
 import { createSignal } from "solid-js";
 import { union, isPathClear } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
+import { isCommandRunning, setIsCommandRunning } from "~/lib/sse";
 
-export const [isLoading, setIsLoading] = createSignal(false);
+export { isCommandRunning as isLoading };
 export const [isPolling, setIsPolling] = createSignal(false);
 
 export type setOperationInput = {
   pattern: string[];
   template: string[];
 };
-let pollingIntervalId: NodeJS.Timeout | null = null;
 
 export const stopPolling = () => {
-  if (pollingIntervalId) clearInterval(pollingIntervalId);
-  pollingIntervalId = null;
   setIsPolling(false);
 };
 
@@ -39,8 +37,6 @@ export const executeUnion = async (
     return;
   }
 
-  setIsLoading(true);
-  stopPolling();
   try {
     if (!(await isPathClear(spacePath))) {
       showToast({
@@ -48,30 +44,22 @@ export const executeUnion = async (
         description: "The space is currently busy. Please wait.",
         variant: "destructive",
       });
-      setIsLoading(false);
       return;
     }
 
+    setIsCommandRunning(true);
     showToast({
       title: "Unification Initiated",
       description: "Waiting for results...",
     });
 
-    const success = await union(unionQuery);
+    await union(unionQuery);
 
-    setIsLoading(false);
-    if (success) {
-      showToast({
-        title: "Unification Complete",
-        description: "Operation completed successfully!",
-      });
-    } else {
-      showToast({
-        title: "Unification Failed",
-        description: "Could not initiate the unification.",
-        variant: "destructive",
-      });
-    }
+    showToast({
+      title: "Unification Complete",
+      description: "Operation completed successfully!",
+    });
+
   } catch (error) {
     const errorMessage =
       error instanceof Error ? error.message : "An unexpected error occurred.";
@@ -81,6 +69,6 @@ export const executeUnion = async (
       variant: "destructive",
     });
   } finally {
-    setIsLoading(false);
+    setIsCommandRunning(false);
   }
 };

--- a/frontend/src/pages/union/lib.ts
+++ b/frontend/src/pages/union/lib.ts
@@ -1,5 +1,5 @@
 import { createSignal } from "solid-js";
-import { union, isPathClear } from "~/lib/api";
+import { union } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
 import { isCommandRunning, setIsCommandRunning } from "~/lib/sse";
 
@@ -38,27 +38,12 @@ export const executeUnion = async (
   }
 
   try {
-    if (!(await isPathClear(spacePath))) {
-      showToast({
-        title: "Space Busy",
-        description: "The space is currently busy. Please wait.",
-        variant: "destructive",
-      });
-      return;
-    }
-
-    setIsCommandRunning(true);
     showToast({
       title: "Unification Initiated",
       description: "Waiting for results...",
     });
 
     await union(unionQuery);
-
-    showToast({
-      title: "Unification Complete",
-      description: "Operation completed successfully!",
-    });
 
   } catch (error) {
     const errorMessage =
@@ -68,7 +53,5 @@ export const executeUnion = async (
       description: errorMessage,
       variant: "destructive",
     });
-  } finally {
-    setIsCommandRunning(false);
   }
 };

--- a/frontend/src/pages/union/lib.ts
+++ b/frontend/src/pages/union/lib.ts
@@ -1,9 +1,10 @@
 import { createSignal } from "solid-js";
 import { union } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
-import { isCommandRunning } from "~/lib/sse";
+import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
 
-export { isCommandRunning as isLoading };
+export const isLoading = () => isCommandActive("UNION");
+export const isAppBusy = isAnyCommandActive;
 export const [isPolling, setIsPolling] = createSignal(false);
 
 export type setOperationInput = {

--- a/frontend/src/pages/upload/Upload.tsx
+++ b/frontend/src/pages/upload/Upload.tsx
@@ -24,6 +24,7 @@ import {
   activeTab,
   setActiveTab,
   isLoading,
+  isAppBusy,
   isFileUploadImplemented,
   handleFileSelect,
   handleImport,
@@ -96,7 +97,7 @@ export const UploadPage: Component = () => {
           <Show when={activeTab() !== "file" || isFileUploadImplemented}>
             <Button
               onClick={handleImportClick}
-              disabled={isLoading() || !isFormValid()}
+              disabled={isAppBusy() || !isFormValid()}
               class="mt-4 px-6"
             >
               <Show

--- a/frontend/src/pages/upload/Upload.tsx
+++ b/frontend/src/pages/upload/Upload.tsx
@@ -97,7 +97,7 @@ export const UploadPage: Component = () => {
           <Show when={activeTab() !== "file" || isFileUploadImplemented}>
             <Button
               onClick={handleImportClick}
-              disabled={isAppBusy() || !isFormValid()}
+              disabled={isAppBusy()}
               class="mt-4 px-6"
             >
               <Show

--- a/frontend/src/pages/upload/Upload.tsx
+++ b/frontend/src/pages/upload/Upload.tsx
@@ -97,7 +97,7 @@ export const UploadPage: Component = () => {
           <Show when={activeTab() !== "file" || isFileUploadImplemented}>
             <Button
               onClick={handleImportClick}
-              disabled={isAppBusy()}
+              disabled={isAppBusy() || !isFormValid()}
               class="mt-4 px-6"
             >
               <Show

--- a/frontend/src/pages/upload/lib.ts
+++ b/frontend/src/pages/upload/lib.ts
@@ -1,7 +1,6 @@
 import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { importData, uploadTextToSpace, importSpace } from "~/lib/api";
-import { refreshSpace } from "../load/lib";
 import { isCommandRunning } from "~/lib/sse";
 
 type UploadResult =

--- a/frontend/src/pages/upload/lib.ts
+++ b/frontend/src/pages/upload/lib.ts
@@ -77,7 +77,7 @@ export const handleImport = async (spacePath: string) => {
             description: `Data import from "${uri()}" has started.`,
           });
 
-          setTimeout(() => refreshSpace(), 3000);
+          refreshSpace();
         } else {
           setResult({ error: "Error initiating import" });
           showToast({

--- a/frontend/src/pages/upload/lib.ts
+++ b/frontend/src/pages/upload/lib.ts
@@ -3,7 +3,6 @@ import { showToast } from "~/components/ui/Toast";
 import { importData, uploadTextToSpace, importSpace } from "~/lib/api";
 import { isCommandRunning } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
-import { ref } from "process";
 
 type UploadResult =
   | null

--- a/frontend/src/pages/upload/lib.ts
+++ b/frontend/src/pages/upload/lib.ts
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { importData, uploadTextToSpace, importSpace } from "~/lib/api";
-import { isCommandRunning } from "~/lib/sse";
+import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
 
 type UploadResult =
@@ -26,7 +26,9 @@ export const [textContent, setTextContent] = createSignal(`()`);
 export const [textFormat, setTextFormat] = createSignal("metta");
 export const [fileFormat, setFileFormat] = createSignal("metta");
 export const [activeTab, setActiveTab] = createSignal("url");
-export { isCommandRunning as isLoading };
+export const isLoading = () =>
+  isCommandActive("IMPORT") || isCommandActive("UPLOAD");
+export const isAppBusy = isAnyCommandActive;
 export const [result, setResult] = createSignal<UploadResult>(null);
 
 export const isFileUploadImplemented = true;

--- a/frontend/src/pages/upload/lib.ts
+++ b/frontend/src/pages/upload/lib.ts
@@ -2,6 +2,7 @@ import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { importData, uploadTextToSpace, importSpace } from "~/lib/api";
 import { refreshSpace } from "../load/lib";
+import { isCommandRunning } from "~/lib/sse";
 
 type UploadResult =
   | null
@@ -25,7 +26,7 @@ export const [textContent, setTextContent] = createSignal(`()`);
 export const [textFormat, setTextFormat] = createSignal("metta");
 export const [fileFormat, setFileFormat] = createSignal("metta");
 export const [activeTab, setActiveTab] = createSignal("url");
-export const [isLoading, setIsLoading] = createSignal(false);
+export { isCommandRunning as isLoading };
 export const [result, setResult] = createSignal<UploadResult>(null);
 
 export const isFileUploadImplemented = true;
@@ -44,7 +45,6 @@ export const handleFileSelect = async (event: Event) => {
 };
 
 export const handleImport = async (spacePath: string) => {
-  setIsLoading(true);
   setResult(null);
 
   try {
@@ -69,17 +69,16 @@ export const handleImport = async (spacePath: string) => {
         const response = await importSpace(spacePath, uri());
 
         if (response) {
-          setResult("Successfully imported to space");
+          setResult("Import initiated successfully");
           showToast({
-            title: "Import Successful",
-            description: `Data was imported from "${uri()}".`,
+            title: "Import Started",
+            description: `Data import from "${uri()}" has started.`,
           });
-          setTimeout(() => refreshSpace(), 1000);
         } else {
-          setResult({ error: "Error importing to space" });
+          setResult({ error: "Error initiating import" });
           showToast({
             title: "Import Failed",
-            description: "Could not import from URL.",
+            description: "Could not initiate import.",
             variant: "destructive",
           });
         }
@@ -113,10 +112,9 @@ export const handleImport = async (spacePath: string) => {
         if (response.status === "success") {
           setResult({ data: response.data, status: "success" });
           showToast({
-            title: "File Uploaded",
-            description: `File "${fileState.name}" uploaded.`,
+            title: "File Upload Started",
+            description: `File "${fileState.name}" upload started.`,
           });
-          refreshSpace();
         } else {
           setResult({ error: response.message });
           showToast({
@@ -150,13 +148,14 @@ export const handleImport = async (spacePath: string) => {
         const cleanText = textContent()
           .replace(/[\r\n]+/g, "\n")
           .trim();
-        const response = await uploadTextToSpace(spacePath, cleanText);
-        setResult({ data: response, status: "success" });
+
+        await uploadTextToSpace(spacePath, cleanText);
+
+        setResult({ data: "Upload initiated", status: "success" });
         showToast({
-          title: "Text Uploaded",
-          description: `Text was uploaded to the "${spacePath}" space.`,
+          title: "Text Upload Started",
+          description: `Text upload to "${spacePath}" started.`,
         });
-        refreshSpace();
         break;
       }
 
@@ -172,8 +171,6 @@ export const handleImport = async (spacePath: string) => {
       description: errorMessage,
       variant: "destructive",
     });
-  } finally {
-    setIsLoading(false);
   }
 };
 

--- a/frontend/src/pages/upload/lib.ts
+++ b/frontend/src/pages/upload/lib.ts
@@ -2,6 +2,8 @@ import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { importData, uploadTextToSpace, importSpace } from "~/lib/api";
 import { isCommandRunning } from "~/lib/sse";
+import { refreshSpace } from "../load/lib";
+import { ref } from "process";
 
 type UploadResult =
   | null
@@ -73,6 +75,8 @@ export const handleImport = async (spacePath: string) => {
             title: "Import Started",
             description: `Data import from "${uri()}" has started.`,
           });
+
+          setTimeout(() => refreshSpace(), 3000);
         } else {
           setResult({ error: "Error initiating import" });
           showToast({
@@ -114,6 +118,7 @@ export const handleImport = async (spacePath: string) => {
             title: "File Upload Started",
             description: `File "${fileState.name}" upload started.`,
           });
+          refreshSpace();
         } else {
           setResult({ error: response.message });
           showToast({


### PR DESCRIPTION
## Description

This PR implements Server-Sent Events (SSE) to provide real-time feedback for long-running operations in the MeTTa-KG application. Previously, operations like uploads or complex transformations provided little to no feedback while processing. This implementation introduces a robust event streaming architecture on the backend and a responsive UI on the frontend.

**Key Changes:**

*   **Backend (`api/src/routes/spaces.rs and command.rs`):**
    *   Refactored `upload`, `import`, `clear`, `transform`, `composition`, and `union` endpoints to run asynchronously.
    *   Introduced `spawn_polling_job` and `execute_polling_job` helper functions to standardize the "dispatch -> poll -> broadcast" pattern, significantly reducing code duplication (DRY).
    *   Implemented sequential processing for `union` operations to ensure data integrity (preventing race conditions between multiple transforms).
    *   Added broadcasting of lifecycle events (`PROCESS_STARTED`, `PROCESS_EXIT_SUCCESS`, `PROCESS_EXIT_ERROR`) and status logs.

*   **Frontend (`frontend/src/lib/sse.ts`, `frontend/src/pages/index/Index.tsx`)**
    *   Implemented an SSE client to consume the `/events` stream.
    *   Added global state signals for command status, progress, and logs.
    *   Integrated a visual progress bar and toast notifications to inform users of operation status.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
