### PR TITLE
fix: Sidebar and Header tear pages with large vertical content

### DIFF
--- a/frontend/src/pages/index/Index.tsx
+++ b/frontend/src/pages/index/Index.tsx
@@ -134,8 +134,8 @@ const AppLayout = (
   const [activeTab, setActiveTab] = createSignal("explore");
 
   return (
-    <div class="w-full h-screen flex ">
-      <div class="flex h-full">
+    <div class="w-full h-screen flex overflow-hidden">
+      <div class="flex-none h-full">
         <Sidebar
           activeTab={activeTab}
           setActiveTab={setActiveTab}
@@ -143,7 +143,7 @@ const AppLayout = (
         />
       </div>
 
-      <div class="w-full h-full flex flex-col">
+      <div class="flex-1 flex flex-col min-w-0 h-full">
         {/* <div class="flex items-center justify-between w-full h-14 shadow-lg shadow-[hsla(var(--secondary-foreground)/0.05)]">
                     <div class="flex items-center">
                         <span class={`text-3xl font-bold text-[hsla(var(--secondary-foreground)/0.7)] ml-10`}>MeTTa-KG</span>
@@ -154,7 +154,7 @@ const AppLayout = (
                 </div> */}
         <Header />
 
-        <div class="flex-1 w-full">{props.children}</div>
+        <div class="flex-1 w-full overflow-y-auto">{props.children}</div>
       </div>
     </div>
   );
@@ -166,8 +166,8 @@ const NotImplementedWrapper = (name: string) => () => (
 
 const App = () => {
   return (
-    <div class="flex">
-      <div class="flex-1 flex flex-col">
+    <div class="h-screen overflow-hidden">
+      <div class="h-full flex flex-col">
         <Router>
           <Route path="*" component={AppLayout}>
             <For each={sidebarSections}>

--- a/frontend/src/pages/index/components/Header.tsx
+++ b/frontend/src/pages/index/components/Header.tsx
@@ -11,7 +11,7 @@ export default function Header() {
   return (
     <>
       {/* Header */}
-      <header class="h-16 bg-neutral-800 border-b border-neutral-700 flex items-center justify-between px-6">
+      <header class="h-16 flex-none bg-neutral-800 border-b border-neutral-700 flex items-center justify-between px-6">
         <NameSpace
           namespace={namespace()}
           setNamespace={setNamespace}

--- a/frontend/src/pages/index/components/Sidebar.tsx
+++ b/frontend/src/pages/index/components/Sidebar.tsx
@@ -18,8 +18,8 @@ export default function Sidebar({
 
   return (
     <>
-      <div class="relative w-80 bg-neutral-900 border-r border-neutral-700">
-        <div class="p-3">
+      <div class="relative w-80 h-full bg-neutral-900 border-r border-neutral-700 flex flex-col">
+        <div class="flex-1 overflow-y-auto p-3">
           <div class="flex items-center gap-2 mb-8">
             <Network class="h-8 w-8 text-primary" />
             <div>


### PR DESCRIPTION
## Description
This PR fixes an issue where the header and slider would tear / break on pages with large vertical content.
The layout now remains stable regardless of content height, and the tearing issue no longer occurs during scrolling or rendering.

## Type of Change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [X] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [X] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.
