### PR TITLE
Fix/single node explore

### DIFF
--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -87,6 +87,12 @@ pub struct ExploreInput {
     pub token: String,
 }
 
+#[derive(Serialize)]
+struct ExploreFallbackItem {
+    token: Vec<u64>,
+    expr: String,
+}
+
 #[derive(Default, Serialize, Deserialize, Clone)]
 pub struct SetOperationInput {
     pub source: Vec<String>,
@@ -215,13 +221,55 @@ pub async fn explore(
     }
 
     let mork_api_client = MorkApiClient::new();
+    let namespace_path = path.clone();
     let request = ExploreRequest::new()
         .namespace(path)
         .pattern(explore_input.pattern.clone())
         .token(explore_input.token.clone());
 
-    let response = mork_api_client.dispatch(request).await.map(Json);
-    response
+    let response_text = mork_api_client.dispatch(request).await?;
+    let trimmed = response_text.trim();
+
+    if explore_input.token.is_empty()
+        && (trimmed.is_empty() || trimmed == "[]" || trimmed == "null")
+    {
+        let transform_input = TransformDetails::new()
+            .patterns(vec![Mm2Cell::new_pattern(
+                explore_input.pattern.clone(),
+                Namespace::from(namespace_path.clone()),
+            )])
+            .templates(vec![Mm2Cell::new_template(
+                "$x".to_string(),
+                Namespace::from(namespace_path),
+            )]);
+        let read_request = ReadRequest::new().transform_input(transform_input);
+
+        if let Ok(raw_text) = mork_api_client.dispatch(read_request).await {
+            let exprs: Vec<String> = raw_text
+                .lines()
+                .map(|line| line.trim())
+                .filter(|line| !line.is_empty())
+                .map(|line| line.to_string())
+                .collect();
+
+            if !exprs.is_empty() {
+                let fallback: Vec<ExploreFallbackItem> = exprs
+                    .into_iter()
+                    .enumerate()
+                    .map(|(index, expr)| ExploreFallbackItem {
+                        token: vec![(index + 1) as u64],
+                        expr,
+                    })
+                    .collect();
+
+                let fallback_json =
+                    json::serde_json::to_string(&fallback).unwrap_or_else(|_| "[]".to_string());
+                return Ok(Json(fallback_json));
+            }
+        }
+    }
+
+    Ok(Json(response_text))
 }
 
 /// Performs an export operation on the `<path..>` space. Get the result that

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -228,44 +228,17 @@ pub async fn explore(
         .token(explore_input.token.clone());
 
     let response_text = mork_api_client.dispatch(request).await?;
-    let trimmed = response_text.trim();
 
-    if explore_input.token.is_empty()
-        && (trimmed.is_empty() || trimmed == "[]" || trimmed == "null")
-    {
-        let transform_input = TransformDetails::new()
-            .patterns(vec![Mm2Cell::new_pattern(
-                explore_input.pattern.clone(),
-                Namespace::from(namespace_path.clone()),
-            )])
-            .templates(vec![Mm2Cell::new_template(
-                "$x".to_string(),
-                Namespace::from(namespace_path),
-            )]);
-        let read_request = ReadRequest::new().transform_input(transform_input);
-
-        if let Ok(raw_text) = mork_api_client.dispatch(read_request).await {
-            let exprs: Vec<String> = raw_text
-                .lines()
-                .map(|line| line.trim())
-                .filter(|line| !line.is_empty())
-                .map(|line| line.to_string())
-                .collect();
-
-            if !exprs.is_empty() {
-                let fallback: Vec<ExploreFallbackItem> = exprs
-                    .into_iter()
-                    .enumerate()
-                    .map(|(index, expr)| ExploreFallbackItem {
-                        token: vec![(index + 1) as u64],
-                        expr,
-                    })
-                    .collect();
-
-                let fallback_json =
-                    json::serde_json::to_string(&fallback).unwrap_or_else(|_| "[]".to_string());
-                return Ok(Json(fallback_json));
-            }
+    // Performs fallback to read if explore returns empty result and no token was provided
+    if explore_input.token.is_empty() && is_empty_explore_response(&response_text) {
+        if let Some(fallback) = fallback_explore_via_read(
+            &mork_api_client,
+            explore_input.pattern.clone(),
+            namespace_path,
+        )
+        .await
+        {
+            return Ok(fallback);
         }
     }
 
@@ -555,6 +528,54 @@ fn union_transform(input: SetOperationInput) -> Result<Vec<TransformDetails>, St
     }
 
     Ok(union_query)
+}
+
+async fn fallback_explore_via_read(
+    client: &MorkApiClient,
+    pattern: String,
+    namespace_path: PathBuf,
+) -> Option<Json<String>> {
+    let transform_input = TransformDetails::new()
+        .patterns(vec![Mm2Cell::new_pattern(
+            pattern.clone(),
+            Namespace::from(namespace_path.clone()),
+        )])
+        .templates(vec![Mm2Cell::new_template(
+            "$x".to_string(),
+            Namespace::from(namespace_path),
+        )]);
+
+    let read_request = ReadRequest::new().transform_input(transform_input);
+
+    let raw_text = client.dispatch(read_request).await.ok()?;
+
+    let exprs: Vec<String> = raw_text
+        .lines()
+        .map(|line| line.trim())
+        .filter(|line| !line.is_empty())
+        .map(String::from)
+        .collect();
+
+    if exprs.is_empty() {
+        return None;
+    }
+
+    let fallback: Vec<ExploreFallbackItem> = exprs
+        .into_iter()
+        .enumerate()
+        .map(|(index, expr)| ExploreFallbackItem {
+            token: vec![(index + 1) as u64],
+            expr,
+        })
+        .collect();
+
+    let json = json::serde_json::to_string(&fallback).ok()?;
+    Some(Json(json))
+}
+
+fn is_empty_explore_response(response_text: &str) -> bool {
+    let trimmed = response_text.trim();
+    trimmed.is_empty() || trimmed == "[]" || trimmed == "null"
 }
 
 // unit tests


### PR DESCRIPTION
## Description

This PR fixes an edge case where the explore endpoint failed to return results when the AtomSpace contained a single matching node. In such cases, explore returned an empty response even though valid data existed.

To address this, a safe fallback mechanism was added:

- When explore returns no results on the initial request (empty token), 
- the API transparently falls back to a read operation, 
- and synthesizes a compatible explore-style response.

The fallback logic has been refactored into a dedicated helper function to keep the route handler clean and maintainable.
All existing behavior remains unchanged for normal traversal scenarios.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [x] Any dependent changes have been merged and published in downstream modules.
