### PR TITLE
Feat/export support for json csv

### DIFF
--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -259,14 +259,14 @@ pub async fn export(
             translations::convert_metta_to_json(mork_response)
                 .map(Json)
                 .map_err(|e| {
-                    Custom(Status::UnprocessableEntity, Json(json!({ "message": "Incompatible metta file: {}" })))
+                    Custom(Status::UnprocessableEntity, Json(json!({ "message": format!("Incompatible metta file: {}", e) })))
                 })
         },
         ExportFormat::Csv => {
             translations::convert_metta_to_csv(mork_response)
                 .map(Json)
                 .map_err(|e| {
-                    Custom(Status::UnprocessableEntity, Json(json!({ "message": "Incompatible metta file: (,)" })))
+                    Custom(Status::UnprocessableEntity, Json(json!({ "message": format!("Incompatible metta file: {}", e) })))
                 })
         },
         _ => Ok(Json(mork_response)),

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -266,7 +266,7 @@ pub async fn export(
             translations::convert_metta_to_csv(mork_response)
                 .map(Json)
                 .map_err(|e| {
-                    Custom(Status::UnprocessableEntity, Json(json!({ "message": format!("Incompatible metta file: {}", e) })))
+                    Custom(Status::UnprocessableEntity, Json(json!({ "message": "Incompatible metta file: (,)" })))
                 })
         },
         _ => Ok(Json(mork_response)),

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -6,6 +6,8 @@ use url::Url;
 
 use rocket::response::status::Custom;
 use rocket::serde::json;
+use rocket::serde::json::serde_json;
+use rocket::serde::json::serde_json::json;
 use rocket::{get, post, Data};
 use std::path::PathBuf;
 use tokio::time::{sleep, Duration, Instant};
@@ -79,6 +81,7 @@ impl SourceTargetPermissions for Mm2InputMultiWithNamespace {
 pub struct Mm2Input {
     pub pattern: String,
     pub template: String,
+    pub format: Option<ExportFormat>,
 }
 
 #[derive(Default, Serialize, Deserialize, Clone)]
@@ -226,15 +229,18 @@ pub async fn explore(
 
 /// Performs an export operation on the `<path..>` space. Get the result that
 /// matches the `<pattern>` by incrementally traversing the resulting space.
+use crate::routes::translations;
 #[post("/spaces/export/<path..>", data = "<export_input>")]
 pub async fn export(
     token: Token,
     path: PathBuf,
     export_input: Json<Mm2Input>,
-) -> Result<Json<String>, Status> {
+) -> Result<Json<String>, Custom<Json<serde_json::Value>>> {
     if !path.starts_with(token.namespace.strip_prefix("/").unwrap()) || !token.permission_read {
-        return Err(Status::Unauthorized);
+        return Err(Custom(Status::Unauthorized, Json(json!({ "message": "Unauthorized" }))));
     }
+
+    let requested_format = export_input.format.clone().unwrap_or(ExportFormat::Metta);
 
     let mork_api_client = MorkApiClient::new();
     let request = ExportRequest::new()
@@ -243,9 +249,27 @@ pub async fn export(
         .template(export_input.template.clone())
         .format(ExportFormat::Metta);
 
-    match mork_api_client.dispatch(request).await {
-        Ok(data) => Ok(Json(data)),
-        Err(e) => Err(e),
+    let mork_response = match mork_api_client.dispatch(request).await {
+        Ok(data) => data,
+        Err(status) => return Err(Custom(status, Json(json!({ "message": "Mork API Error" })))),
+    };
+
+    match requested_format {
+        ExportFormat::Json => {
+            translations::convert_metta_to_json(mork_response)
+                .map(Json)
+                .map_err(|e| {
+                    Custom(Status::UnprocessableEntity, Json(json!({ "message": "Incompatible metta file: {}" })))
+                })
+        },
+        ExportFormat::Csv => {
+            translations::convert_metta_to_csv(mork_response)
+                .map(Json)
+                .map_err(|e| {
+                    Custom(Status::UnprocessableEntity, Json(json!({ "message": format!("Incompatible metta file: {}", e) })))
+                })
+        },
+        _ => Ok(Json(mork_response)),
     }
 }
 

--- a/api/src/routes/translations.rs
+++ b/api/src/routes/translations.rs
@@ -207,17 +207,18 @@ pub async fn create_from_n3(
 }
 
 pub fn convert_metta_to_json(metta_content: String) -> Result<String, std::io::Error> {
-    run_python_conversion("translations/src/metta_to_json_run.py", metta_content)
+    run_python_conversion("translations/src/metta_to_json_run.py", metta_content, "json")
 }
 
 pub fn convert_metta_to_csv(metta_content: String) -> Result<String, std::io::Error> {
-    run_python_conversion("translations/src/metta_to_csv_run.py", metta_content)
+    run_python_conversion("translations/src/metta_to_csv_run.py", metta_content, "csv")
 }
 
-fn run_python_conversion(script_path: &str, content: String) -> Result<String, std::io::Error> {
+fn run_python_conversion(script_path: &str, content: String, extension: &str) -> Result<String, std::io::Error> {
     let id = Uuid::new_v4();
+    let _ = fs::create_dir_all("temp");
     let temp_path = format!("temp/export-{id}.metta");
-    let output_path = format!("temp/export-{id}.json");
+    let output_path = format!("temp/export-{id}.{extension}");
     
     {
         let mut file = fs::File::create(&temp_path)?;

--- a/api/src/routes/translations.rs
+++ b/api/src/routes/translations.rs
@@ -7,6 +7,8 @@ use std::fs;
 use std::process::Command;
 use uuid::Uuid;
 
+use std::io::Write;
+
 #[derive(FromFormField, Copy, Clone)]
 pub enum CSVParseDirection {
     Row = 1,
@@ -202,4 +204,42 @@ pub async fn create_from_n3(
     )
     .await
     .map(Json)
+}
+
+pub fn convert_metta_to_json(metta_content: String) -> Result<String, std::io::Error> {
+    run_python_conversion("translations/src/metta_to_json_run.py", metta_content)
+}
+
+pub fn convert_metta_to_csv(metta_content: String) -> Result<String, std::io::Error> {
+    run_python_conversion("translations/src/metta_to_csv_run.py", metta_content)
+}
+
+fn run_python_conversion(script_path: &str, content: String) -> Result<String, std::io::Error> {
+    let id = Uuid::new_v4();
+    let temp_path = format!("temp/export-{id}.metta");
+    let output_path = format!("temp/export-{id}.json");
+    
+    {
+        let mut file = fs::File::create(&temp_path)?;
+        file.write_all(content.as_bytes())?;
+    }
+    
+    let output = Command::new("./venv/bin/python")
+        .arg(script_path)
+        .arg(&temp_path)
+        .arg(&output_path)
+        .output()?;
+
+    // Clean up temp file
+    let _ = fs::remove_file(temp_path);
+
+    if output.status.success() {
+        let result = fs::read_to_string(&output_path)?;
+        let _ = fs::remove_file(output_path);
+        Ok(result)
+    } else {
+        let _ = fs::remove_file(output_path);
+        let err = String::from_utf8_lossy(&output.stderr).to_string();
+        Err(std::io::Error::new(std::io::ErrorKind::Other, err))
+    }
 }

--- a/api/tests/test_export.rs
+++ b/api/tests/test_export.rs
@@ -36,6 +36,7 @@ async fn test_export_success() {
     let export_input = Mm2Input {
         pattern: "$x".to_string(),
         template: "($x)".to_string(),
+        format: None,
     };
 
     let response = client
@@ -71,6 +72,7 @@ async fn test_non_existent_namespace() {
     let export_input = Mm2Input {
         pattern: "$x".to_string(),
         template: "($x)".to_string(),
+        format: None,
     };
 
     // Path does not start with /test/
@@ -112,6 +114,7 @@ async fn test_existing_empty_namespace() {
     let export_input = Mm2Input {
         pattern: "$x".to_string(),
         template: "($x)".to_string(),
+        format: None,
     };
 
     let response = client
@@ -154,6 +157,7 @@ async fn test_non_empty_namespace() {
     let export_input = Mm2Input {
         pattern: "$x".to_string(),
         template: "($x)".to_string(),
+        format: None,
     };
 
     let response = client
@@ -196,6 +200,7 @@ async fn test_different_namespaces() {
     let export_input = Mm2Input {
         pattern: "$x".to_string(),
         template: "($x)".to_string(),
+        format: None,
     };
 
     // Export from ns1
@@ -238,6 +243,7 @@ async fn test_namespace_mismatch() {
     let export_input = Mm2Input {
         pattern: "$x".to_string(),
         template: "($x)".to_string(),
+        format: None,
     };
 
     // Path does not start with /test/

--- a/frontend/src/lib/types.d.ts
+++ b/frontend/src/lib/types.d.ts
@@ -26,6 +26,7 @@ export interface ExploreDetail {
 export interface Mm2Input {
   pattern: string[] | string;
   template: string[] | string;
+  format?: string;
 }
 export interface Mm2CellValue {
   value: string;

--- a/frontend/src/pages/export/Export.tsx
+++ b/frontend/src/pages/export/Export.tsx
@@ -25,6 +25,7 @@ import {
   result,
   exportError,
   handleExport,
+  ExportFormat,
 } from "./lib";
 
 const ExportPage: Component = () => {
@@ -72,7 +73,7 @@ const ExportPage: Component = () => {
 
           <TextField class="space-y-2">
             <TextFieldLabel for="export-format">Format</TextFieldLabel>
-            <Select
+            <Select<ExportFormat>
               options={["metta", "json", "csv", "raw"]}
               value={format()}
               onChange={setFormat}

--- a/frontend/src/pages/export/Export.tsx
+++ b/frontend/src/pages/export/Export.tsx
@@ -122,6 +122,7 @@ const ExportPage: Component = () => {
               title="Export Result"
               data={exportError() ? exportError()!.message : result()}
               status={exportError() ? "error" : "success"}
+              format={format()}
             />
           </div>
         </Show>

--- a/frontend/src/pages/export/components/OutputViewer.tsx
+++ b/frontend/src/pages/export/components/OutputViewer.tsx
@@ -8,7 +8,7 @@ import { Callout, CalloutContent } from "~/components/ui/Callout";
 interface OutputViewerProps {
   title?: string;
   data: any /* eslint-disable-line @typescript-eslint/no-explicit-any */;
-  format?: "json" | "text" | "metta";
+  format?: "json" | "text" | "metta" | "csv" | "raw" | string;
   status?: "success" | "error" | "loading";
 }
 
@@ -20,7 +20,17 @@ export function OutputViewer(props: OutputViewerProps): JSX.Element {
 
     switch (props.format) {
       case "json":
-        return JSON.stringify(props.data, null, 2);
+        try {
+          const parsed =
+            typeof props.data === "string"
+              ? JSON.parse(props.data)
+              : props.data;
+          return JSON.stringify(parsed, null, 2);
+        } catch {
+          return typeof props.data === "string"
+            ? props.data
+            : JSON.stringify(props.data, null, 2);
+        }
       case "text":
       case "metta":
       default:

--- a/frontend/src/pages/export/components/OutputViewer.tsx
+++ b/frontend/src/pages/export/components/OutputViewer.tsx
@@ -8,7 +8,7 @@ import { Callout, CalloutContent } from "~/components/ui/Callout";
 interface OutputViewerProps {
   title?: string;
   data: any /* eslint-disable-line @typescript-eslint/no-explicit-any */;
-  format?: "json" | "text" | "metta" | "csv" | "raw" | string;
+  format?: "json" | "text" | "metta" | "csv";
   status?: "success" | "error" | "loading";
 }
 

--- a/frontend/src/pages/export/components/OutputViewer.tsx
+++ b/frontend/src/pages/export/components/OutputViewer.tsx
@@ -8,7 +8,7 @@ import { Callout, CalloutContent } from "~/components/ui/Callout";
 interface OutputViewerProps {
   title?: string;
   data: any /* eslint-disable-line @typescript-eslint/no-explicit-any */;
-  format?: "json" | "text" | "metta" | "csv";
+  format?: "json" | "text" | "metta" | "csv" | "raw";
   status?: "success" | "error" | "loading";
 }
 

--- a/frontend/src/pages/export/lib.ts
+++ b/frontend/src/pages/export/lib.ts
@@ -15,6 +15,7 @@ export const handleExport = async (spacePath: string) => {
   const exportInput: Mm2Input = {
     pattern: pattern().trim() || "$x",
     template: template().trim() || "$x",
+    format: format().charAt(0).toUpperCase() + format().slice(1),
   };
 
   setIsLoading(true);
@@ -22,14 +23,6 @@ export const handleExport = async (spacePath: string) => {
   setExportError(null);
 
   try {
-    if (format() !== "metta") {
-      showToast({
-        title: "Format Not Supported Yet",
-        description: `${format()} format not supported yet. Please use metta format.`,
-        variant: "destructive",
-      });
-      return;
-    }
     const exportResponse = await exportSpace(spacePath, exportInput);
     setResult(exportResponse || "()");
     showToast({
@@ -39,10 +32,16 @@ export const handleExport = async (spacePath: string) => {
   } catch (e) {
     const error = e instanceof Error ? e : new Error("Failed to export data");
     setExportError(error);
-    setResult(error.message);
+
+    let errorMessage = error.message;
+    if (errorMessage.includes("Incompatible metta file")) {
+      errorMessage = "Incompatible metta file";
+    }
+
+    setResult(null);
     showToast({
       title: "Error",
-      description: error.message,
+      description: errorMessage,
       variant: "destructive",
     });
   } finally {

--- a/frontend/src/pages/export/lib.ts
+++ b/frontend/src/pages/export/lib.ts
@@ -3,8 +3,9 @@ import { showToast } from "~/components/ui/Toast";
 import { exportSpace } from "~/lib/api";
 import { Mm2Input } from "~/lib/types";
 
+export type ExportFormat = "metta" | "json" | "csv" | "raw";
 export const [uri, setUri] = createSignal("");
-export const [format, setFormat] = createSignal("metta");
+export const [format, setFormat] = createSignal<ExportFormat>("metta");
 export const [isLoading, setIsLoading] = createSignal(false);
 export const [pattern, setPattern] = createSignal("$x\n\n\n");
 export const [template, setTemplate] = createSignal("$x\n\n\n");
@@ -24,7 +25,10 @@ export const handleExport = async (spacePath: string) => {
 
   try {
     const exportResponse = await exportSpace(spacePath, exportInput);
-    setResult(exportResponse || "()");
+    
+    const defaultResult = exportInput.format === "Metta" ? "()" : "";
+    setResult(exportResponse || defaultResult);
+    
     showToast({
       title: "Export Complete",
       description: `Exported data with pattern: ${exportInput.pattern}`,

--- a/translations/src/json_to_metta.py
+++ b/translations/src/json_to_metta.py
@@ -51,7 +51,8 @@ def dict_to_metta(f: IO[str], d: dict) -> None:
         # TODO escape strings
         if isinstance(s, str):
             # s = '"' + s.replace('\\', '\\\\').replace('"', '\\"') + '"'
-            s = f'"{repr(s)[1:-1].replace("\\", "\\\\").replace('"', '\\"')}"'
+            escaped = repr(s)[1:-1].replace("\\", "\\\\").replace('"', '\\"')
+            s = f'"{escaped}"'
 
         for item in reversed(path[:-1]):
             if isinstance(item, tuple):
@@ -68,7 +69,8 @@ def dict_list_to_metta(f: IO[str], ds: list[dict]) -> None:
             # TODO escape strings
             if isinstance(s, str):
                 # s = '"' + s.replace('\\', '\\\\').replace('"', '\\"') + '"'
-                s = f'"{repr(s)[1:-1].replace("\\", "\\\\").replace('"', '\\"')}"'
+                escaped = repr(s)[1:-1].replace("\\", "\\\\").replace('"', '\\"')
+                s = f'"{escaped}"'
 
             for item in reversed(path[:-1]):
                 if isinstance(item, tuple):

--- a/translations/src/json_to_metta.py
+++ b/translations/src/json_to_metta.py
@@ -96,7 +96,7 @@ def expr_to_path(e: hyperon.Atom) -> list:
 def metta_to_dict(f: IO[str]) -> dict:
     # it feels too hard to recognize arrays unhinted
     m = hyperon.MeTTa()
-    es = m.parse_all(f.read())
+    es = m.parse_all(f)
     d = {}
     # print("atoms", len(es))
     for e in es:

--- a/translations/src/json_to_metta.py
+++ b/translations/src/json_to_metta.py
@@ -96,7 +96,7 @@ def expr_to_path(e: hyperon.Atom) -> list:
 def metta_to_dict(f: IO[str]) -> dict:
     # it feels too hard to recognize arrays unhinted
     m = hyperon.MeTTa()
-    es = m.parse_all(f)
+    es = m.parse_all(f.read())
     d = {}
     # print("atoms", len(es))
     for e in es:

--- a/translations/src/metta_to_csv_run.py
+++ b/translations/src/metta_to_csv_run.py
@@ -1,0 +1,59 @@
+import sys
+import os
+import hyperon
+from io import StringIO
+import csv
+
+# Add current directory to path to allow importing sibling modules
+# Add current directory and src directory to path to allow importing modules
+sys.path.append(os.path.dirname(__file__))
+sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
+
+
+def metta_to_list(metta_string):
+    m = hyperon.MeTTa()
+    # Parse the string into atoms
+    atoms = m.parse_all(metta_string)
+    if not atoms:
+        return []
+    result = []
+    for atom in atoms:
+        result.append(atom.get_children())
+    return result
+
+def matrix_to_csv_str(m: list[list[any]]) -> str:
+    si = StringIO()
+    writer = csv.writer(si, delimiter=',', quotechar='\'', quoting=csv.QUOTE_NONE, escapechar='\'')
+    for row in m:
+        converted_row = []
+        for item in row:
+            if isinstance(item, hyperon.SymbolAtom):
+                val = item.get_name()
+                converted_row.append(val)
+            elif isinstance(item, hyperon.GroundedAtom):
+                converted_row.append(item.get_object().value)
+            elif isinstance(item, hyperon.ExpressionAtom):
+                converted_row.append(item)
+        writer.writerow(converted_row)
+    return si.getvalue()
+
+
+if __name__ == "__main__":
+    try:
+        filename = sys.argv[1]
+        output_filename = sys.argv[2]
+        with open(filename, 'r') as f:
+            content = f.read()
+        
+        # Parse MeTTa content
+        matrix = metta_to_list(content)
+        # metta = parse_metta(content)
+
+        # # Convert matrix to CSV string
+        csv_output = matrix_to_csv_str(matrix)
+        
+        with open(output_filename, 'w') as f:
+            f.write(csv_output)
+    except Exception as e:
+        sys.stderr.write(str(e))
+        sys.exit(1)

--- a/translations/src/metta_to_csv_run.py
+++ b/translations/src/metta_to_csv_run.py
@@ -47,9 +47,8 @@ if __name__ == "__main__":
         
         # Parse MeTTa content
         matrix = metta_to_list(content)
-        # metta = parse_metta(content)
 
-        # # Convert matrix to CSV string
+        # Convert matrix to CSV string
         csv_output = matrix_to_csv_str(matrix)
         
         with open(output_filename, 'w') as f:

--- a/translations/src/metta_to_csv_run.py
+++ b/translations/src/metta_to_csv_run.py
@@ -3,11 +3,9 @@ import os
 import hyperon
 from io import StringIO
 import csv
+from typing import Any
 
-# Add current directory to path to allow importing sibling modules
-# Add current directory and src directory to path to allow importing modules
 sys.path.append(os.path.dirname(__file__))
-sys.path.append(os.path.join(os.path.dirname(__file__), 'src'))
 
 
 def metta_to_list(metta_string):
@@ -21,7 +19,7 @@ def metta_to_list(metta_string):
         result.append(atom.get_children())
     return result
 
-def matrix_to_csv_str(m: list[list[any]]) -> str:
+def matrix_to_csv_str(m: list[list[Any]]) -> str:
     si = StringIO()
     writer = csv.writer(si, delimiter=',', quotechar='\'', quoting=csv.QUOTE_NONE, escapechar='\'')
     for row in m:

--- a/translations/src/metta_to_json_run.py
+++ b/translations/src/metta_to_json_run.py
@@ -12,7 +12,12 @@ if __name__ == "__main__":
         filename = sys.argv[1]
         output_filename = sys.argv[2]
         with open(filename, 'r') as f:
-            result = metta_to_dict(f)
+            content = f.read()
+    
+        # Replace consecutive double quotes with a single double quote
+        result = content.replace('""', '"')
+        
+        result = metta_to_dict(result)
         
         with open(output_filename, 'w') as f:
             json.dump(result, f)

--- a/translations/src/metta_to_json_run.py
+++ b/translations/src/metta_to_json_run.py
@@ -1,0 +1,21 @@
+import sys
+import os
+import json
+
+# Add current directory to path to allow importing sibling modules
+sys.path.append(os.path.dirname(__file__))
+
+from json_to_metta import metta_to_dict
+
+if __name__ == "__main__":
+    try:
+        filename = sys.argv[1]
+        output_filename = sys.argv[2]
+        with open(filename, 'r') as f:
+            result = metta_to_dict(f)
+        
+        with open(output_filename, 'w') as f:
+            json.dump(result, f)
+    except Exception as e:
+        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        sys.exit(1)

--- a/translations/src/metta_to_json_run.py
+++ b/translations/src/metta_to_json_run.py
@@ -1,23 +1,26 @@
 import sys
 import os
 import json
+from typing import IO
+from io import StringIO
 
 # Add current directory to path to allow importing sibling modules
 sys.path.append(os.path.dirname(__file__))
 
 from json_to_metta import metta_to_dict
 
+def prepare_file(f: IO[str]) -> IO[str]:
+    content = f.read()
+    content = content.replace('""', '"')
+    return StringIO(content)
+
 if __name__ == "__main__":
     try:
         filename = sys.argv[1]
         output_filename = sys.argv[2]
         with open(filename, 'r') as f:
-            content = f.read()
-    
-        # Replace consecutive double quotes with a single double quote
-        result = content.replace('""', '"')
-        
-        result = metta_to_dict(result)
+            f_prepared = prepare_file(f)
+            result = metta_to_dict(f_prepared)
         
         with open(output_filename, 'w') as f:
             json.dump(result, f)


### PR DESCRIPTION
This pull request adds support for exporting data from spaces in multiple formats (Metta, JSON, and CSV), both on the backend and frontend. It introduces new backend endpoints and format conversion logic, updates the API and frontend to handle new formats, and improves error handling and output display. The most important changes are grouped below:

**Backend: Export Format Support and Conversion**
- Added an optional `format` field to the `Mm2Input` struct and updated the `/spaces/export` endpoint to accept and handle requests for Metta, JSON, or CSV exports. The endpoint now returns structured JSON error messages and uses the requested format to convert exported data accordingly. 
- Implemented `convert_metta_to_json` and `convert_metta_to_csv` functions in the backend, which invoke new Python scripts to perform the actual conversion from Metta to JSON or CSV.
- Added two new Python scripts: `metta_to_json_run.py` and `metta_to_csv_run.py`, which perform the respective conversions using Hyperon and custom logic. 

**Frontend: UI and Logic Updates**
- Updated the export UI to allow selection and display of different export formats (including CSV), and improved the `OutputViewer` component to correctly parse and display JSON output. 
- Modified the export logic to send the selected format to the backend and improved error handling to show user-friendly messages for format incompatibility or conversion errors. 

**Miscellaneous**
- Improved string escaping in the JSON-to-Metta conversion script for safer output. 
- Added necessary imports and minor code cleanups to support the new features. 

These changes together enable seamless export of data in multiple formats, with robust error handling and improved user experience.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] I have read the [**Contributing Guidelines**](./CONTRIBUTING.md).
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [x] New and existing unit tests pass locally with my changes.
- [ ] Any dependent changes have been merged and published in downstream modules.