### PR TITLE
Feat/task scheduling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,8 @@ Cargo.lock
 # MSVC Windows builds of rustc generate these, which store debugging information
 *.pdb
 
+res.rest
+
 .idea
 
 .env

--- a/api/src/lib.rs
+++ b/api/src/lib.rs
@@ -9,6 +9,7 @@ pub mod db;
 pub mod model;
 pub mod mork_api;
 pub mod routes;
+pub mod scheduler;
 pub mod schema;
 pub mod sse_utils;
 

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -311,13 +311,13 @@ pub async fn export(
                 message: "Export completed successfully.".to_string(),
             });
             let _ = broadcaster.send(ServerEvent::Success {
-                message: "Export done".to_string(),
+                message: "EXPORT".to_string(),
             });
             data
         }
         Err(e) => {
             let _ = broadcaster.send(ServerEvent::Error {
-                message: format!("{:?}", e),
+                message: "EXPORT".to_string(),
             });
 
             return Err(Custom(e, Json(json!({ "message": "Mork API Error" }))));

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -22,6 +22,7 @@ use crate::mork_api::{
     TransformDetails, TransformRequest, UploadRequest,
 };
 use crate::routes::sse::SseState;
+use crate::scheduler::acquire_write_lock;
 use crate::sse_utils::{JobRunner, ServerEvent};
 
 trait SourceTargetPermissions {
@@ -567,14 +568,7 @@ pub async fn union(
             let path = request_path;
             let write_lock = write_lock;
             async move {
-                let lock_guard = if let Ok(guard) = write_lock.try_lock() {
-                    guard
-                } else {
-                    let _ = tx.send(ServerEvent::Log {
-                        message: "Write queue busy, waiting for turn...".to_string(),
-                    });
-                    write_lock.lock().await
-                };
+                let lock_guard = acquire_write_lock(&write_lock, &tx).await;
 
                 let _ = tx.send(ServerEvent::Log {
                     message: "Starting union operation...".to_string(),
@@ -683,14 +677,7 @@ fn spawn_job<R>(
         command,
         broadcaster,
         move |tx: broadcast::Sender<ServerEvent>| async move {
-            let lock_guard = if let Ok(guard) = write_lock.try_lock() {
-                guard
-            } else {
-                let _ = tx.send(ServerEvent::Log {
-                    message: "Write queue busy, waiting for turn...".to_string(),
-                });
-                write_lock.lock().await
-            };
+            let lock_guard = acquire_write_lock(&write_lock, &tx).await;
 
             mork_api_client
                 .dispatch(request)

--- a/api/src/routes/spaces.rs
+++ b/api/src/routes/spaces.rs
@@ -10,7 +10,9 @@ use rocket::serde::json::serde_json;
 use rocket::serde::json::serde_json::json;
 use rocket::{get, post, Data, State};
 use std::path::PathBuf;
+use std::sync::Arc;
 use tokio::sync::broadcast;
+use tokio::sync::Mutex;
 use tokio::time::{sleep, Duration, Instant};
 
 use crate::model::Token;
@@ -180,7 +182,15 @@ pub async fn upload(
         .data(body);
 
     let broadcaster = state.broadcaster.clone();
-    spawn_job("UPLOAD", broadcaster, mork_api_client, request, path);
+    let write_lock = state.write_lock.clone();
+    spawn_job(
+        "UPLOAD",
+        broadcaster,
+        write_lock,
+        mork_api_client,
+        request,
+        path,
+    );
 
     Ok(Json(true))
 }
@@ -207,9 +217,11 @@ pub async fn import(
     let request = ImportRequest::new().to(template).uri(uri);
 
     let broadcaster = state.broadcaster.clone();
+    let write_lock = state.write_lock.clone();
     spawn_job(
         "IMPORT",
         broadcaster,
+        write_lock,
         mork_api_client,
         request,
         path.clone(),
@@ -349,7 +361,15 @@ pub async fn clear(
     let request = ClearRequest::new().namespace(path.clone()).expr(expr);
 
     let broadcaster = state.broadcaster.clone();
-    spawn_job("CLEAR", broadcaster, mork_api_client, request, path.clone());
+    let write_lock = state.write_lock.clone();
+    spawn_job(
+        "CLEAR",
+        broadcaster,
+        write_lock,
+        mork_api_client,
+        request,
+        path.clone(),
+    );
 
     Ok(Json(true))
 }
@@ -374,6 +394,7 @@ pub async fn transform(
     );
 
     let broadcaster = state.broadcaster.clone();
+    let write_lock = state.write_lock.clone();
     // We need a target path to poll. In transform, templates define the target.
     // Assuming the first template's namespace is the target for polling.
     let request_path = match mm2.templates.first() {
@@ -385,7 +406,14 @@ pub async fn transform(
     // Convert Namespace to PathBuf for polling
     let path_buf = PathBuf::from(request_path.to_string());
 
-    spawn_job("TRANSFORM", broadcaster, mork_api_client, request, path_buf);
+    spawn_job(
+        "TRANSFORM",
+        broadcaster,
+        write_lock,
+        mork_api_client,
+        request,
+        path_buf,
+    );
 
     Ok(Json(true))
 }
@@ -421,6 +449,7 @@ pub async fn composition(
     let request = TransformRequest::new().transform_input(transform_input.clone());
     let mork_api_client = MorkApiClient::new();
     let broadcaster = state.broadcaster.clone();
+    let write_lock = state.write_lock.clone();
 
     // Target path for polling is the first target in the input
     let request_path = match input.target.first() {
@@ -431,6 +460,7 @@ pub async fn composition(
     spawn_job(
         "COMPOSITION",
         broadcaster,
+        write_lock,
         mork_api_client,
         request,
         request_path,
@@ -466,6 +496,7 @@ pub async fn intersection(
     let request = TransformRequest::new().transform_input(transform_input);
     let mork_api_client = MorkApiClient::new();
     let broadcaster = state.broadcaster.clone();
+    let write_lock = state.write_lock.clone();
 
     // Target path for polling is the first target in the input
     let request_path = match input.target.first() {
@@ -476,6 +507,7 @@ pub async fn intersection(
     spawn_job(
         "INTERSECTION",
         broadcaster,
+        write_lock,
         mork_api_client,
         request,
         request_path,
@@ -504,6 +536,7 @@ pub async fn union(
     let transform_inputs = union_transform(operation_input.into_inner())?;
     let mork_api_client = MorkApiClient::new();
     let broadcaster = state.broadcaster.clone();
+    let write_lock = state.write_lock.clone();
 
     JobRunner::spawn(
         "UNION",
@@ -511,7 +544,17 @@ pub async fn union(
         move |tx: broadcast::Sender<ServerEvent>| {
             let client = mork_api_client;
             let path = request_path;
+            let write_lock = write_lock;
             async move {
+                let lock_guard = if let Ok(guard) = write_lock.try_lock() {
+                    guard
+                } else {
+                    let _ = tx.send(ServerEvent::Log {
+                        message: "Write queue busy, waiting for turn...".to_string(),
+                    });
+                    write_lock.lock().await
+                };
+
                 let _ = tx.send(ServerEvent::Log {
                     message: "Starting union operation...".to_string(),
                 });
@@ -532,6 +575,8 @@ pub async fn union(
                         .await
                         .map_err(|e| format!("Processing timeout: {:?}", e))?;
                 }
+
+                drop(lock_guard);
                 Ok("Union complete".to_string())
             }
         },
@@ -594,6 +639,7 @@ async fn poll_and_broadcast(
 fn spawn_job<R>(
     command: &str,
     broadcaster: broadcast::Sender<ServerEvent>,
+    write_lock: Arc<Mutex<()>>,
     mork_api_client: MorkApiClient,
     request: R,
     request_path: PathBuf,
@@ -616,6 +662,15 @@ fn spawn_job<R>(
         command,
         broadcaster,
         move |tx: broadcast::Sender<ServerEvent>| async move {
+            let lock_guard = if let Ok(guard) = write_lock.try_lock() {
+                guard
+            } else {
+                let _ = tx.send(ServerEvent::Log {
+                    message: "Write queue busy, waiting for turn...".to_string(),
+                });
+                write_lock.lock().await
+            };
+
             mork_api_client
                 .dispatch(request)
                 .await
@@ -628,6 +683,8 @@ fn spawn_job<R>(
             poll_and_broadcast(request_path, &mork_api_client, &tx)
                 .await
                 .map_err(|e| format!("Processing timeout: {:?}", e))?;
+
+            drop(lock_guard);
 
             Ok(success_msg)
         },

--- a/api/src/routes/sse.rs
+++ b/api/src/routes/sse.rs
@@ -4,11 +4,14 @@ use rocket::futures::stream::{self as futures_stream};
 use rocket::response::stream::{Event, EventStream};
 use rocket::State;
 use rocket::{get, routes};
+use std::sync::Arc;
 use tokio::sync::broadcast;
+use tokio::sync::Mutex;
 
 #[derive(Clone)]
 pub struct SseState {
     pub broadcaster: broadcast::Sender<ServerEvent>,
+    pub write_lock: Arc<Mutex<()>>,
 }
 
 #[get("/events")]
@@ -28,9 +31,13 @@ pub fn stream(state: &State<SseState>) -> EventStream<impl rocket::futures::Stre
 pub fn stage() -> AdHoc {
     AdHoc::on_ignite("SSE Processor", |rocket| async {
         let (tx_bc, _) = broadcast::channel::<ServerEvent>(100);
+        let write_lock = Arc::new(Mutex::new(()));
 
         rocket
-            .manage(SseState { broadcaster: tx_bc })
+            .manage(SseState {
+                broadcaster: tx_bc,
+                write_lock,
+            })
             .mount("/", routes![stream])
     })
 }

--- a/api/src/scheduler.rs
+++ b/api/src/scheduler.rs
@@ -1,0 +1,18 @@
+use crate::sse_utils::ServerEvent;
+use std::sync::Arc;
+use tokio::sync::broadcast;
+use tokio::sync::Mutex;
+
+pub async fn acquire_write_lock<'a>(
+    write_lock: &'a Arc<Mutex<()>>,
+    broadcaster: &broadcast::Sender<ServerEvent>,
+) -> tokio::sync::MutexGuard<'a, ()> {
+    if let Ok(guard) = write_lock.try_lock() {
+        guard
+    } else {
+        let _ = broadcaster.send(ServerEvent::Log {
+            message: "Write queue busy, waiting for turn...".to_string(),
+        });
+        write_lock.lock().await
+    }
+}

--- a/api/src/sse_utils.rs
+++ b/api/src/sse_utils.rs
@@ -15,8 +15,12 @@ impl From<ServerEvent> for Event {
         match event {
             ServerEvent::Started { command } => Event::data(format!("PROCESS_STARTED:{}", command)),
             ServerEvent::Log { message } => Event::data(message),
-            ServerEvent::Success { .. } => Event::data("PROCESS_EXIT_SUCCESS"),
-            ServerEvent::Error { .. } => Event::data("PROCESS_EXIT_ERROR"),
+            ServerEvent::Success { message } => {
+                Event::data(format!("PROCESS_EXIT_SUCCESS:{}", message))
+            }
+            ServerEvent::Error { message } => {
+                Event::data(format!("PROCESS_EXIT_ERROR:{}", message))
+            }
         }
     }
 }
@@ -32,20 +36,24 @@ impl JobRunner {
     {
         let command = command_name.to_string();
         tokio::spawn(async move {
-            let _ = broadcaster.send(ServerEvent::Started { command });
+            let _ = broadcaster.send(ServerEvent::Started {
+                command: command.clone(),
+            });
 
             match task(broadcaster.clone()).await {
                 Ok(msg) => {
                     let _ = broadcaster.send(ServerEvent::Log { message: msg });
                     let _ = broadcaster.send(ServerEvent::Success {
-                        message: "Done".into(),
+                        message: command.clone(),
                     });
                 }
                 Err(err) => {
                     let _ = broadcaster.send(ServerEvent::Log {
                         message: format!("Error: {}", err),
                     });
-                    let _ = broadcaster.send(ServerEvent::Error { message: err });
+                    let _ = broadcaster.send(ServerEvent::Error {
+                        message: command.clone(),
+                    });
                 }
             }
         });

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -58,10 +58,14 @@ export const initSSE = () => {
       return;
     }
 
-    if (data === "PROCESS_EXIT_SUCCESS") {
-      const cmdName = activeCommand();
-      setCommandProgress(100);
-      setActiveCommand(null);
+    if (data.startsWith("PROCESS_EXIT_SUCCESS")) {
+      const parts = data.split(":");
+      const cmdName =
+        parts.length > 1 ? (parts[1] as CommandType) : activeCommand();
+      if (activeCommand() === cmdName) {
+        setCommandProgress(100);
+        setActiveCommand(null);
+      }
       showToast({
         title: "Success",
         description: `${cmdName} completed successfully`,
@@ -69,9 +73,13 @@ export const initSSE = () => {
       return;
     }
 
-    if (data === "PROCESS_EXIT_ERROR") {
-      const cmdName = activeCommand();
-      setActiveCommand(null);
+    if (data.startsWith("PROCESS_EXIT_ERROR")) {
+      const parts = data.split(":");
+      const cmdName =
+        parts.length > 1 ? (parts[1] as CommandType) : activeCommand();
+      if (activeCommand() === cmdName) {
+        setActiveCommand(null);
+      }
       showToast({
         title: "Error",
         description: `${cmdName} failed`,

--- a/frontend/src/lib/sse.ts
+++ b/frontend/src/lib/sse.ts
@@ -22,6 +22,9 @@ export const [commandLogs, setCommandLogs] = createSignal<string[]>([]);
 export const isCommandActive = (type: CommandType) => activeCommand() === type;
 export const isAnyCommandActive = () => activeCommand() !== null;
 export const isCommandRunning = isAnyCommandActive;
+export const isCommandQueued = (type: CommandType) =>
+  isCommandActive(type) &&
+  commandLogs().some((line) => line.includes("waiting for turn"));
 
 let eventSource: EventSource | null = null;
 

--- a/frontend/src/pages/clear/Clear.tsx
+++ b/frontend/src/pages/clear/Clear.tsx
@@ -4,7 +4,13 @@ import { CommandCard } from "~/components/common/CommandCard";
 import MettaEditor from "~/components/common/MettaEditor";
 import Loader2 from "lucide-solid/icons/loader-2";
 import { formatedNamespace } from "~/lib/state";
-import { expression, setExpression, isLoading, handleClear } from "./lib";
+import {
+  expression,
+  setExpression,
+  isLoading,
+  isQueued,
+  handleClear,
+} from "./lib";
 
 const ClearPage: Component = () => {
   return (
@@ -31,7 +37,9 @@ const ClearPage: Component = () => {
             >
               <Show when={isLoading()} fallback={"Clear Data"}>
                 <Loader2 class="animate-spin mr-2" />
-                Clearing...
+                <Show when={isQueued()} fallback={"Clearing..."}>
+                  Queued...
+                </Show>
               </Show>
             </Button>
             <p class="text-sm text-muted-foreground">

--- a/frontend/src/pages/clear/Clear.tsx
+++ b/frontend/src/pages/clear/Clear.tsx
@@ -31,7 +31,7 @@ const ClearPage: Component = () => {
           <div class="flex items-center gap-4 pt-2">
             <Button
               onClick={() => handleClear(formatedNamespace())}
-              disabled={isAppBusy() || isLoading() || !expression().trim()}
+              disabled={isLoading() || !expression().trim()}
               variant="destructive"
               class="w-36"
             >

--- a/frontend/src/pages/clear/lib.ts
+++ b/frontend/src/pages/clear/lib.ts
@@ -1,11 +1,12 @@
 import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { clearSpace } from "~/lib/api";
-import { isCommandRunning } from "~/lib/sse";
+import { isCommandActive, isCommandQueued } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
 
 export const [expression, setExpression] = createSignal("$x \n \n \n");
-export { isCommandRunning as isLoading };
+export const isLoading = () => isCommandActive("CLEAR");
+export const isQueued = () => isCommandQueued("CLEAR");
 
 export const handleClear = async (spacePath: string) => {
   if (!expression().trim()) {

--- a/frontend/src/pages/composition/Composition.tsx
+++ b/frontend/src/pages/composition/Composition.tsx
@@ -13,7 +13,7 @@ import { getAllTokens } from "~/lib/api";
 import { rootToken, tokenRootNamespace } from "~/lib/state";
 import {
   isLoading,
-  isAppBusy,
+  isQueued,
   isPolling,
   executeComposition,
   stopPolling,
@@ -203,7 +203,7 @@ const CompositionPage: Component = () => {
 
         <Button
           onClick={handleComposition}
-          disabled={isAppBusy() || !canCompose()}
+          disabled={isLoading() || !canCompose()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>
@@ -230,7 +230,9 @@ const CompositionPage: Component = () => {
               </Show>
             }
           >
-            Performing Composition...
+            <Show when={isQueued()} fallback={"Performing Composition..."}>
+              Queued...
+            </Show>
           </Show>
         </Button>
       </CommandCard>

--- a/frontend/src/pages/composition/lib.ts
+++ b/frontend/src/pages/composition/lib.ts
@@ -1,11 +1,11 @@
 import { createSignal } from "solid-js";
 import { composition } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
-import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
+import { isCommandActive, isCommandQueued } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
 
 export const isLoading = () => isCommandActive("COMPOSITION");
-export const isAppBusy = isAnyCommandActive;
+export const isQueued = () => isCommandQueued("COMPOSITION");
 export const [isPolling, setIsPolling] = createSignal(false);
 
 export type setOperationInput = {

--- a/frontend/src/pages/export/Export.tsx
+++ b/frontend/src/pages/export/Export.tsx
@@ -36,6 +36,7 @@ import {
   isInputValid,
   handleInput,
   ExportFormat,
+  activeExportAction,
 } from "./lib";
 
 const ExportPage: Component = () => {
@@ -122,7 +123,7 @@ const ExportPage: Component = () => {
           <Button
             onClick={() => handleExport(formatedNamespace())}
             disabled={
-              !!isLoading() ||
+              isAppBusy() ||
               !pattern().trim() ||
               !template().trim() ||
               !isInputValid(maxWrite())
@@ -130,7 +131,7 @@ const ExportPage: Component = () => {
             class="w-36"
           >
             <Show
-              when={isLoading() === "export"}
+              when={isLoading() && activeExportAction() === "export"}
               fallback={
                 <>
                   <Download class="mr-2 h-4 w-4" />
@@ -145,11 +146,11 @@ const ExportPage: Component = () => {
 
           <Button
             onClick={() => handleDownload(formatedNamespace())}
-            disabled={!!isLoading() || !pattern().trim() || !template().trim()}
+            disabled={isAppBusy() || !pattern().trim() || !template().trim()}
             class="w-37"
           >
             <Show
-              when={isLoading() === "download"}
+              when={isLoading() && activeExportAction() === "download"}
               fallback={
                 <>
                   <Download class="mr-2 h-4 w-4" />

--- a/frontend/src/pages/export/Export.tsx
+++ b/frontend/src/pages/export/Export.tsx
@@ -22,7 +22,7 @@ import {
   format,
   setFormat,
   isLoading,
-  isAppBusy,
+  isQueued,
   pattern,
   setPattern,
   template,
@@ -89,7 +89,7 @@ const ExportPage: Component = () => {
                   options={["metta", "json", "csv", "raw"]}
                   value={format()}
                   onChange={setFormat}
-                  disabled={!!isLoading() || isAppBusy()}
+                  disabled={!!isLoading()}
                   placeholder="Select a format"
                   itemComponent={(props) => (
                     <SelectItem item={props.item}>
@@ -123,7 +123,7 @@ const ExportPage: Component = () => {
           <Button
             onClick={() => handleExport(formatedNamespace())}
             disabled={
-              isAppBusy() ||
+              isLoading() ||
               !pattern().trim() ||
               !template().trim() ||
               !isInputValid(maxWrite())
@@ -140,13 +140,15 @@ const ExportPage: Component = () => {
               }
             >
               <Loader2 class="mr-2 h-4 w-4 animate-spin" />
-              Exporting...
+              <Show when={isQueued()} fallback={"Exporting..."}>
+                Queued...
+              </Show>
             </Show>
           </Button>
 
           <Button
             onClick={() => handleDownload(formatedNamespace())}
-            disabled={isAppBusy() || !pattern().trim() || !template().trim()}
+            disabled={isLoading() || !pattern().trim() || !template().trim()}
             class="w-37"
           >
             <Show
@@ -159,7 +161,9 @@ const ExportPage: Component = () => {
               }
             >
               <Loader2 class="mr-2 h-4 w-4 animate-spin" />
-              Exporting...
+              <Show when={isQueued()} fallback={"Exporting..."}>
+                Queued...
+              </Show>
             </Show>
           </Button>
         </div>

--- a/frontend/src/pages/export/lib.ts
+++ b/frontend/src/pages/export/lib.ts
@@ -2,14 +2,15 @@ import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { exportSpace } from "~/lib/api";
 import { Mm2Input } from "~/lib/types";
-import { isAnyCommandActive } from "~/lib/sse";
+import { isAnyCommandActive, isCommandActive } from "~/lib/sse";
 
 export type ExportFormat = "metta" | "json" | "csv" | "raw";
 export const [uri, setUri] = createSignal("");
-export const [isLoading, setIsLoading] = createSignal<
+export const [activeExportAction, setActiveExportAction] = createSignal<
   false | "export" | "download"
 >(false);
 export const [format, setFormat] = createSignal<ExportFormat>("metta");
+export const isLoading = () => isCommandActive("EXPORT");
 export const isAppBusy = isAnyCommandActive;
 export const [pattern, setPattern] = createSignal("$x\n\n\n");
 export const [template, setTemplate] = createSignal("$x\n\n\n");
@@ -25,7 +26,7 @@ export const handleExport = async (spacePath: string) => {
     format: format().charAt(0).toUpperCase() + format().slice(1),
   };
 
-  setIsLoading("export");
+  setActiveExportAction("export");
   setResult(null);
   setExportError(null);
 
@@ -55,7 +56,7 @@ export const handleExport = async (spacePath: string) => {
       variant: "destructive",
     });
   } finally {
-    setIsLoading(false);
+    setActiveExportAction(false);
   }
 };
 
@@ -67,7 +68,7 @@ export const handleDownload = async (spacePath: string) => {
     format: currentFormat.charAt(0).toUpperCase() + currentFormat.slice(1),
   };
 
-  setIsLoading("download");
+  setActiveExportAction("download");
   setResult(null);
   setExportError(null);
 
@@ -109,7 +110,7 @@ export const handleDownload = async (spacePath: string) => {
       variant: "destructive",
     });
   } finally {
-    setIsLoading(false);
+    setActiveExportAction(false);
   }
 };
 export const isInputValid = (val: number | null) => {

--- a/frontend/src/pages/export/lib.ts
+++ b/frontend/src/pages/export/lib.ts
@@ -2,7 +2,7 @@ import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { exportSpace } from "~/lib/api";
 import { Mm2Input } from "~/lib/types";
-import { isAnyCommandActive, isCommandActive } from "~/lib/sse";
+import { isCommandActive, isCommandQueued } from "~/lib/sse";
 
 export type ExportFormat = "metta" | "json" | "csv" | "raw";
 export const [uri, setUri] = createSignal("");
@@ -11,7 +11,7 @@ export const [activeExportAction, setActiveExportAction] = createSignal<
 >(false);
 export const [format, setFormat] = createSignal<ExportFormat>("metta");
 export const isLoading = () => isCommandActive("EXPORT");
-export const isAppBusy = isAnyCommandActive;
+export const isQueued = () => isCommandQueued("EXPORT");
 export const [pattern, setPattern] = createSignal("$x\n\n\n");
 export const [template, setTemplate] = createSignal("$x\n\n\n");
 export const [result, setResult] = createSignal<string | null>(null);

--- a/frontend/src/pages/intersection/Intersection.tsx
+++ b/frontend/src/pages/intersection/Intersection.tsx
@@ -21,7 +21,7 @@ import {
   isPolling,
   executeIntersection,
   stopPolling,
-  isAppBusy,
+  isQueued,
 } from "./lib";
 
 const IntersectionPage: Component = () => {
@@ -181,7 +181,7 @@ const IntersectionPage: Component = () => {
           </div>
           <Button
             class="w-full mt-4"
-            disabled={!canSubmit() || isLoading() || isPolling() || isAppBusy()}
+            disabled={!canSubmit() || isLoading() || isPolling()}
             onClick={handleIntersection}
           >
             <Show when={isLoading() || isPolling()}>
@@ -208,7 +208,9 @@ const IntersectionPage: Component = () => {
                 </Show>
               }
             >
-              Processing...
+              <Show when={isQueued()} fallback={"Processing..."}>
+                Queued...
+              </Show>
             </Show>
           </Button>
         </div>

--- a/frontend/src/pages/intersection/lib.ts
+++ b/frontend/src/pages/intersection/lib.ts
@@ -2,11 +2,11 @@ import { createSignal } from "solid-js";
 import { request } from "~/lib/api";
 import { namespace } from "~/lib/state";
 import { showToast } from "~/components/ui/Toast";
-import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
+import { isCommandActive, isCommandQueued } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
 
 export const isLoading = () => isCommandActive("INTERSECTION");
-export const isAppBusy = isAnyCommandActive;
+export const isQueued = () => isCommandQueued("INTERSECTION");
 export const [isPolling, setIsPolling] = createSignal(false);
 
 export const stopPolling = () => {

--- a/frontend/src/pages/load/lib.ts
+++ b/frontend/src/pages/load/lib.ts
@@ -41,9 +41,11 @@ export const [subSpace, { refetch: refetchSubSpace, mutate: mutateSubSpace }] =
     }),
     async ({ path, expr, token }) => {
       try {
-        const data = JSON.parse(
-          await exploreSpace(path, expr, token)
-        ) as ExploreResponse[];
+        const response = await exploreSpace(path, expr, token);
+        const data =
+          typeof response === "string"
+            ? (JSON.parse(response) as ExploreResponse[])
+            : (response as unknown as ExploreResponse[]);
         showToast({
           title: "Success",
           description: `Loaded ${data.length} nodes.`,
@@ -61,19 +63,25 @@ export const [subSpace, { refetch: refetchSubSpace, mutate: mutateSubSpace }] =
   );
 
 export const refreshSpace = async () => {
-  // If a command is running, wait for it to finish
-  if (isCommandRunning()) {
-    await new Promise<void>((resolve) => {
-      createRoot((dispose) => {
-        createEffect(() => {
-          if (!isCommandRunning()) {
-            dispose();
-            resolve();
-          }
+  const waitUntilIdle = async () => {
+    if (isCommandRunning()) {
+      await new Promise<void>((resolve) => {
+        createRoot((dispose) => {
+          createEffect(() => {
+            if (!isCommandRunning()) {
+              dispose();
+              resolve();
+            }
+          });
         });
       });
-    });
-  }
+    }
+  };
+
+  await waitUntilIdle();
+  await new Promise((resolve) => setTimeout(resolve, 250));
+  await waitUntilIdle();
+
   mutateSubSpace([]);
   treeStore.reset();
   return refetchSubSpace();

--- a/frontend/src/pages/transform/Transform.tsx
+++ b/frontend/src/pages/transform/Transform.tsx
@@ -16,7 +16,7 @@ import {
   isPolling,
   executeTransform,
   stopPolling,
-  isAppBusy,
+  isQueued,
 } from "./lib";
 import Copy from "lucide-solid/icons/copy";
 import Check from "lucide-solid/icons/check";
@@ -180,7 +180,7 @@ const TransformPage: Component = () => {
 
         <Button
           onClick={handleTransform}
-          disabled={isAppBusy() || isPolling() || !canTransform()}
+          disabled={isLoading() || isPolling() || !canTransform()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>
@@ -207,7 +207,9 @@ const TransformPage: Component = () => {
               </Show>
             }
           >
-            Transforming...
+            <Show when={isQueued()} fallback={"Transforming..."}>
+              Queued...
+            </Show>
           </Show>
         </Button>
       </CommandCard>

--- a/frontend/src/pages/transform/lib.ts
+++ b/frontend/src/pages/transform/lib.ts
@@ -2,11 +2,11 @@ import { createSignal } from "solid-js";
 import { transform } from "~/lib/api";
 import { Mm2InputMultiWithNamespace, Item } from "~/lib/types";
 import { showToast } from "~/components/ui/Toast";
-import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
+import { isCommandActive, isCommandQueued } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
 
 export const isLoading = () => isCommandActive("TRANSFORM");
-export const isAppBusy = isAnyCommandActive;
+export const isQueued = () => isCommandQueued("TRANSFORM");
 export const [isPolling, setIsPolling] = createSignal(false);
 
 export const stopPolling = () => {

--- a/frontend/src/pages/union/Union.tsx
+++ b/frontend/src/pages/union/Union.tsx
@@ -13,7 +13,7 @@ import { getAllTokens } from "~/lib/api";
 import { rootToken, tokenRootNamespace } from "~/lib/state";
 import {
   isLoading,
-  isAppBusy,
+  isQueued,
   isPolling,
   executeUnion,
   stopPolling,
@@ -208,7 +208,7 @@ const UnionPage: Component = () => {
 
         <Button
           onClick={handleUnion}
-          disabled={isAppBusy() || isPolling() || !canUnion()}
+          disabled={isLoading() || isPolling() || !canUnion()}
           class="inline-flex items-center justify-center w-[180px] h-10 mt-4"
         >
           <Show when={isLoading() || isPolling()}>
@@ -235,7 +235,9 @@ const UnionPage: Component = () => {
               </Show>
             }
           >
-            Performing Union...
+            <Show when={isQueued()} fallback={"Performing Union..."}>
+              Queued...
+            </Show>
           </Show>
         </Button>
       </CommandCard>

--- a/frontend/src/pages/union/lib.ts
+++ b/frontend/src/pages/union/lib.ts
@@ -1,11 +1,11 @@
 import { createSignal } from "solid-js";
 import { union } from "~/lib/api";
 import { showToast } from "~/components/ui/Toast";
-import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
+import { isCommandActive, isCommandQueued } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
 
 export const isLoading = () => isCommandActive("UNION");
-export const isAppBusy = isAnyCommandActive;
+export const isQueued = () => isCommandQueued("UNION");
 export const [isPolling, setIsPolling] = createSignal(false);
 
 export type setOperationInput = {

--- a/frontend/src/pages/upload/Upload.tsx
+++ b/frontend/src/pages/upload/Upload.tsx
@@ -24,7 +24,7 @@ import {
   activeTab,
   setActiveTab,
   isLoading,
-  isAppBusy,
+  isQueued,
   isFileUploadImplemented,
   handleFileSelect,
   handleImport,
@@ -97,7 +97,7 @@ export const UploadPage: Component = () => {
           <Show when={activeTab() !== "file" || isFileUploadImplemented}>
             <Button
               onClick={handleImportClick}
-              disabled={isAppBusy() || !isFormValid()}
+              disabled={isLoading() || !isFormValid()}
               class="mt-4 px-6"
             >
               <Show
@@ -113,7 +113,10 @@ export const UploadPage: Component = () => {
                   </>
                 }
               >
-                <Loader class="mr-2 h-4 w-4 animate-spin" /> Processing...
+                <Loader class="mr-2 h-4 w-4 animate-spin" />
+                <Show when={isQueued()} fallback={"Processing..."}>
+                  Queued...
+                </Show>
               </Show>
             </Button>
           </Show>

--- a/frontend/src/pages/upload/lib.ts
+++ b/frontend/src/pages/upload/lib.ts
@@ -1,7 +1,7 @@
 import { createSignal } from "solid-js";
 import { showToast } from "~/components/ui/Toast";
 import { importData, uploadTextToSpace, importSpace } from "~/lib/api";
-import { isCommandActive, isAnyCommandActive } from "~/lib/sse";
+import { isCommandActive, isCommandQueued } from "~/lib/sse";
 import { refreshSpace } from "../load/lib";
 
 type UploadResult =
@@ -28,7 +28,8 @@ export const [fileFormat, setFileFormat] = createSignal("metta");
 export const [activeTab, setActiveTab] = createSignal("url");
 export const isLoading = () =>
   isCommandActive("IMPORT") || isCommandActive("UPLOAD");
-export const isAppBusy = isAnyCommandActive;
+export const isQueued = () =>
+  isCommandQueued("IMPORT") || isCommandQueued("UPLOAD");
 export const [result, setResult] = createSignal<UploadResult>(null);
 
 export const isFileUploadImplemented = true;


### PR DESCRIPTION
This pull request adds a global write lock to the backend to ensure only one write operation (such as CLEAR, UPLOAD, COMPOSITION, etc.) is processed at a time, and updates the frontend to display a "Queued..." status when a command is waiting for the lock. It also improves event messages for more accurate UI updates and user feedback.

**Backend: Write Lock Implementation and Integration**
- Introduced a global write lock using `tokio::sync::Mutex` in the backend, ensuring only one write operation can be processed at a time. The lock is shared via the `SseState` struct and acquired in all relevant routes before starting a write job (`api/src/routes/sse.rs`, `api/src/lib.rs`, `api/src/routes/spaces.rs`, `api/src/scheduler.rs`). - When the lock is busy, a log message ("Write queue busy, waiting for turn...") is broadcast to the frontend so the UI can indicate the queued state (`api/src/scheduler.rs`).

**Backend: Event and Broadcast Improvements**
- Enhanced SSE event messages to include the command name for both success and error events, allowing the frontend to accurately track which command completed (`api/src/sse_utils.rs`, `api/src/routes/spaces.rs`). 

**Frontend: Queued State Display**
- Added logic to detect when a command is queued (waiting for the write lock) and display "Queued..." on action buttons in the UI for Clear and Composition pages (`frontend/src/lib/sse.ts`, `frontend/src/pages/clear/Clear.tsx`, `frontend/src/pages/clear/lib.ts`, `frontend/src/pages/composition/Composition.tsx`, `frontend/src/pages/composition/lib.ts`).
- Updated frontend event handling to parse the new event message format and only clear the active command when the correct command completes or fails (`frontend/src/lib/sse.ts`).

These changes improve consistency, prevent concurrent write issues, and provide clearer feedback to users about the status of their requests.